### PR TITLE
Added some documentation to alert_box

### DIFF
--- a/lib/bh/helpers/alert_helper.rb
+++ b/lib/bh/helpers/alert_helper.rb
@@ -12,9 +12,9 @@ module Bh
     # The message to display in the alert can either be passed as the first
     # parameter (in which case, the options are the second parameter), or as
     # a block (in which case, the options are the first parameter).
-    # @example An alert with a plain-text message passed as the first parameter.
+    # @example An alert with a plain-text message passed as the first parameter (if you want to pass HTML use a block).
     #   alert 'User updated successfully', dismissible: true
-    # @example An alert with an HTML message passed as a block.
+    # @example An alert with a HTML message passed as a block.
     #   alert_box dismissible: true do
     #     content_tag :strong, "User updated successfully"
     #   end

--- a/spec/dummy/index.html.erb
+++ b/spec/dummy/index.html.erb
@@ -9,6 +9,10 @@ layout: default
 <h1>Alerts</h1>
 
 <%= alert_box 'You accepted the Terms of service.', context: :success, dismissible: true %>
+<p>Alert with link (passed as a block)</p>
+<%= alert_box title: 'Thanks', context: :info, &Proc.new{link_to('Link', '#')} %>
+<p>Alert with link (passed as an argument)</p>
+<%= alert_box link_to('Link', '#'), title: 'Thanks', context: :info %>
 
 <p>Alert boxes with HTML content currently not supported in Middleman.</p>
 


### PR DESCRIPTION
Added documentation to `AlertBoxHelper` explaining that passing HTML should be accomplished by using a block rather that an argument. If a `link_to` is passed as a regular argument it wont add `alert-link` class to the link element.
