### PR TITLE
Add `:fieldset` option to `fields_for`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For more information about changelogs, check
 * [FEATURE] Add `font_awesome_css` helper
 * [FEATURE] Add `dropdown` helper
 * [FEATURE] Add `progress_bar` helper
+* [ENHANCEMENT] Add `:fieldset` option to decide whether `fields_for` should wrap fields in a <fieldset> tag
 
 ## 1.0.1 - 2014-09-14
 

--- a/lib/bh/helpers/form/fields_for_helper.rb
+++ b/lib/bh/helpers/form/fields_for_helper.rb
@@ -14,7 +14,9 @@ module Bh
         fields_options[:layout] ||= @options[:layout]
         fields_options[:errors] ||= @options[:errors]
         title = fields_options.delete(:title) { record_name.to_s.humanize }
-        fieldset(title) { super record_name, record_object, fields_options, &block }
+        wrap_in_fieldset = fields_options.fetch :fieldset, true
+        fields = super record_name, record_object, fields_options, &block
+        wrap_in_fieldset ? fieldset(title) { fields } : fields
       end
     end
   end

--- a/spec/helpers/form/fields_for_helper_spec.rb
+++ b/spec/helpers/form/fields_for_helper_spec.rb
@@ -12,26 +12,42 @@ describe 'fields_for' do
   let(:title) { nil }
   let(:fields_block) { Proc.new {|f| f.text_field :street } }
 
-  specify 'adds a <fieldset> that looks like a Bootstrap panel' do
-    expect(form).to include 'fieldset class="panel panel-default">'
+  describe 'with the :fieldset option' do
+    specify 'not set, wraps the fields in a <fieldset> styled like a panel' do
+      expect(form).to include 'fieldset class="panel panel-default">'
+    end
+
+    describe 'set to true, wraps the fields in a <fieldset> styled like a panel' do
+      let(:options) { {fieldset: true} }
+      it { expect(form).to include 'fieldset class="panel panel-default">' }
+    end
+
+    describe 'set to false, does not wrap the fields in a <fieldset>' do
+      let(:options) { {fieldset: false} }
+      it { expect(form).not_to include 'fieldset' }
+    end
   end
 
-  context 'given a title option, uses the provided title' do
-    let(:options) { {title: 'Your address'} }
-    it { expect(form).to include '<div class="panel-heading">Your address</div>' }
+  describe 'with the :title option' do
+    specify 'not set, generates a title from the field name' do
+      expect(form).to include '<div class="panel-heading">Address</div>'
+    end
+
+    context 'set to a value, uses the value as the panel title' do
+      let(:options) { {title: 'Your address'} }
+      it { expect(form).to include '<div class="panel-heading">Your address</div>' }
+    end
   end
 
-  specify 'not given a title, generates one from the field name' do
-    expect(form).to include '<div class="panel-heading">Address</div>'
-  end
+  describe 'with the :layout option' do
+    specify 'not set, inherits the layout options of the parent form' do
+      expect(form).to match %r{<div class="form-group"><label for.+?>Street</label>}
+    end
 
-  specify 'given no layout, inherits the layout options of the parent form' do
-    expect(form).to match %r{<div class="form-group"><label for.+?>Street</label>}
-  end
-
-  context 'given a layout, uses its own layout' do
-    let(:options) { {layout: :horizontal} }
-    it { expect(form).to match %r{<div class="form-group"><label class="col-sm-3 control-label" for.+?>Street</label>} }
+    context 'set to a value, uses the value as the layout' do
+      let(:options) { {layout: :horizontal} }
+      it { expect(form).to match %r{<div class="form-group"><label class="col-sm-3 control-label" for.+?>Street</label>} }
+    end
   end
 
   context 'given a record object' do


### PR DESCRIPTION
By default `fields_for` wraps the fields in a `<fieldset>` tag (which is styled as a panel).
After this commit, the behavior can be disabled by passing the `fieldset: false` option to `fields_for`.
Closes #30.

---

After this commit, here is how you can wrap fields in a form.
1. Without any fieldset: just use the field helpers inside the form
   
   ``` rhtml
     <%= f.text_field :budget, prefix:'$' %>
     <%= f.text_field :cost_per_unit, prefix: '$' %>
   ```
   
   ![1](https://cloud.githubusercontent.com/assets/10076/4338791/db95eef8-401c-11e4-9b8d-cc5cb096748e.png)
2. With a fieldset that does not uses a panel: manually add the `<fieldset>..</fieldset>` around the fields. I think that this is not a common case: why would someone specify that some fields create a "field set" and not separate them from the rest? Anyway, if that's the case, it can still be achieved (and looks like 1.):
   
   ``` rhtml
     <fieldset>
       <%= f.text_field :budget, prefix:'$' %>
       <%= f.text_field :cost_per_unit, prefix: '$' %>
     </fieldset>
   ```
   
   ![2](https://cloud.githubusercontent.com/assets/10076/4338792/dd5a13ea-401c-11e4-9485-1062e7ed43da.png)
3. With a fieldset that uses a panel: use the `fieldset` helper (with or without optional title):
   
   ``` rhtml
     <%= f.fieldset 'Price' do %>
       <%= f.text_field :budget, prefix:'$' %>
       <%= f.text_field :cost_per_unit, prefix: '$' %>
     <% end %>
   ```
   
   ![3](https://cloud.githubusercontent.com/assets/10076/4338795/e2b256c2-401c-11e4-878c-c95cb96670dd.png)
4. With a fields_for that wraps fields in a `<fieldset>` tag (and therefore looks like 3.): use the `fields_for` helper:
   
   ``` rhtml
     <%= f.fields_for :price do |price_f| %>
       <%= price_f.text_field :budget, prefix:'$' %>
       <%= price_f.text_field :cost_per_unit, prefix: '$' %>
     <% end %>
   ```
   
   ![4](https://cloud.githubusercontent.com/assets/10076/4338796/e44c63d8-401c-11e4-9357-bcd1f47784cb.png)
5. With a fields_for that does not wrap fields in a `<fieldset>` tag (and therefore looks like 1. and 2.): use the `fields_for` helper with the `fieldset: false` option:
   
   ``` rhtml
     <%= f.fields_for :price, fieldset: false do |price_f| %>
       <%= price_f.text_field :budget, prefix:'$' %>
       <%= price_f.text_field :cost_per_unit, prefix: '$' %>
     <% end %>
   ```
   
   ![5](https://cloud.githubusercontent.com/assets/10076/4338797/e59c4168-401c-11e4-9a2a-2e927f3558ae.png)
