### PR TITLE
Add button helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For more information about changelogs, check
 * [FEATURE] Add `dropdown` helper
 * [FEATURE] Add `progress_bar` helper
 * [ENHANCEMENT] Add `:fieldset` option to decide whether `fields_for` should wrap fields in a <fieldset> tag
+* [FEATURE] Add `button` helper
 
 ## 1.0.1 - 2014-09-14
 

--- a/lib/bh/helpers/button_helper.rb
+++ b/lib/bh/helpers/button_helper.rb
@@ -1,0 +1,63 @@
+require 'bh/helpers/base_helper'
+
+module Bh
+  # Provides methods to include buttons.
+  # @see http://getbootstrap.com/components/#buttons
+  module ButtonHelper
+    include BaseHelper
+
+    # Returns an HTML block tag that follows the Bootstrap documentation
+    # on how to display *buttons*.
+    #
+    # The content of the button can either be passed as the first parameter (in
+    # which case, the options are the second parameter), or as a block (in
+    # which case, the options are the first paramter).
+    # @example An button with plain-text content passed as the first parameter.
+    #   <%= button 'Your profile was updated!', context: :info %>
+    # @example A button with HTML content passed as a block.
+    #   <%= button context: :info %>
+    #     <%= glyphicon :star %> Star
+    #   <% end %>
+    #
+    # @return [String] an HTML block tag for a button.
+    # @param [String] content_or_options_with_block the content to display in
+    #   the button.
+    # @param [Hash] options the display options for the button.
+    # @option options [#to_s] :context (:default) the contextual alternative to
+    #   apply to the button depending on its importance. Can be :default,
+    #   :primary, :success, :info, :warning, :danger or :link.
+    # @option options [#to_s] :size the size of the button.
+    # @option options [#to_s] :layout if set to :block, span the button for
+    #   the full width of the parent.
+    def button(content_or_options_with_block = nil, options = nil, &block)
+      if block_given?
+        button_string capture(&block), content_or_options_with_block || {}
+      else
+        button_string content_or_options_with_block, options || {}
+      end
+    end
+
+  private
+
+    def button_string(content = nil, options = {})
+      append_class! options, btn_class(options)
+      content_tag :button, content, options
+    end
+
+    def btn_class(options = {})
+      valid_contexts = %w(primary success info warning danger link)
+      context = context_for options.delete(:context), valid: valid_contexts
+      "btn btn-#{context}"
+
+      size = case options.delete(:size).to_s
+        when 'lg', 'large' then 'btn-lg'
+        when 'sm', 'small' then 'btn-sm'
+        when 'xs', 'extra_small' then 'btn-xs'
+      end
+
+      layout = 'btn-block' if options.delete(:layout).to_s == 'block'
+
+      ['btn', "btn-#{context}", size, layout].compact.join ' '
+    end
+  end
+end

--- a/lib/bh/helpers/dropdown_helper.rb
+++ b/lib/bh/helpers/dropdown_helper.rb
@@ -17,7 +17,7 @@ module Bh
     # generates a link *surrounded by a list item* and with the appropriate
     # menu item attributes.
     # @example A right-aligned dropdown with two links.
-    #   <%= dropdown align: :right do %>
+    #   <%= dropdown 'Menu', align: :right do %>
     #     <%= link_to 'Home', '/' %>
     #     <%= link_to 'Profile', '/profile' %>
     #   <% end %>

--- a/lib/bh/middleman.rb
+++ b/lib/bh/middleman.rb
@@ -1,4 +1,5 @@
 require 'bh/helpers/alert_helper'
+require 'bh/helpers/button_helper'
 require 'bh/helpers/button_to_helper'
 require 'bh/helpers/cdn_helper'
 require 'bh/helpers/dropdown_helper'
@@ -17,6 +18,7 @@ module Bh
   class MiddlemanExtension < Middleman::Extension
     helpers do
       include AlertHelper
+      include ButtonHelper
       include ButtonToHelper
       include CdnHelper
       include DropdownHelper

--- a/lib/bh/railtie.rb
+++ b/lib/bh/railtie.rb
@@ -1,4 +1,5 @@
 require 'bh/helpers/alert_helper'
+require 'bh/helpers/button_helper'
 require 'bh/helpers/button_to_helper'
 require 'bh/helpers/cdn_helper'
 require 'bh/helpers/dropdown_helper'
@@ -17,6 +18,7 @@ module Bh
   class Railtie < Rails::Railtie
     initializer 'bh.add_helpers' do
       ActionView::Base.send :include, AlertHelper
+      ActionView::Base.send :include, ButtonHelper
       ActionView::Base.send :include, ButtonToHelper
       ActionView::Base.send :include, CdnHelper
       ActionView::Base.send :include, DropdownHelper

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -1,0 +1,100 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'bh/helpers/button_helper'
+include Bh::ButtonHelper
+
+describe 'button' do
+  describe 'accepts as parameters:' do
+    let(:behave) { match %r{^<button class="btn.+?">content</button>} }
+
+    specify 'a string (content)' do
+      expect(button 'content').to behave
+    end
+
+    specify 'a block (content)' do
+      expect(button { 'content' }).to behave
+    end
+
+    specify 'a string (content) + a hash (options)' do
+      expect(button 'content', context: :danger).to behave
+    end
+
+    specify 'a hash (options) + a block (content)' do
+      expect(button(context: :danger) { 'content' }).to behave
+    end
+  end
+
+  describe 'with the :context option' do
+    let(:html) { button 'content', context: context }
+
+    describe 'set to :primary, shows a "primary" button' do
+      let(:context) { :primary }
+      it { expect(html).to include 'btn-primary' }
+    end
+
+    describe 'set to :success, shows a "success" button' do
+      let(:context) { :success }
+      it { expect(html).to include 'btn-success' }
+    end
+
+    describe 'set to :info, shows a "info" button' do
+      let(:context) { :info }
+      it { expect(html).to include 'btn-info' }
+    end
+
+    describe 'set to :warning, shows a "warning" button' do
+      let(:context) { :warning }
+      it { expect(html).to include 'btn-warning' }
+    end
+
+    describe 'set to :danger, shows a "danger" button' do
+      let(:context) { :danger }
+      it { expect(html).to include 'btn-danger' }
+    end
+
+    describe 'set to :link, shows a "link" button' do
+      let(:context) { :link }
+      it { expect(html).to include 'btn-link' }
+    end
+
+    describe 'set to any other value, shows a "default" button' do
+      let(:context) { :unknown }
+      it { expect(html).to include 'btn-default' }
+    end
+  end
+
+  describe 'without the :context option, shows a "default" button' do
+    let(:html) { button 'content' }
+    it { expect(html).to include 'btn-default' }
+  end
+
+  describe 'with the :size option' do
+    let(:html) { button 'content', size: size }
+
+    describe 'set to :large, shows a large button' do
+      let(:size) { :large }
+      it { expect(html).to include 'btn-lg' }
+    end
+
+    describe 'set to :small, shows a small button' do
+      let(:size) { :small }
+      it { expect(html).to include 'btn-sm' }
+    end
+
+    describe 'set to :extra_small, shows an extra-small button' do
+      let(:size) { :extra_small }
+      it { expect(html).to include 'btn-xs' }
+    end
+  end
+
+
+  describe 'with the :layout option' do
+    let(:html) { button 'content', layout: layout }
+
+    describe 'set to :block, shows a "block" button' do
+      let(:layout) { :block }
+      it { expect(html).to include 'btn-block' }
+    end
+  end
+end


### PR DESCRIPTION
Although Bh already has a `button_to` helper to go along with ActionView, a `button` helper is also required for places where buttons do not need to be part of a form.
