### PR TITLE
Add bh_label helper

### DIFF
--- a/lib/bh/helpers/label_helper.rb
+++ b/lib/bh/helpers/label_helper.rb
@@ -1,0 +1,33 @@
+require 'bh/helpers/base_helper'
+
+module Bh
+  # Provides methods to include vector icons from different libraries.
+  # @see http://getbootstrap.com/components/#glyphicons
+  # @see http://fortawesome.github.io/Font-Awesome/examples/#bootstrap
+  module LabelHelper
+    include BaseHelper
+
+    # Returns an HTML span tag to display a Bootstrap label.
+    # @see http://getbootstrap.com/components/#labels
+    #
+    # @return [String] an HTML span tag for a label.
+    # @param [String] text The text to display in the label.
+    # @param [Hash] options the options for the label.
+    # @option options [#to_s] :context (:default) the contextual alternative to
+    #   apply to the label depending on its importance. Can be :primary, :success, 
+    #   :info, :warning, or :danger.
+    #
+    # @example Display a label with the default styling.
+    #   bh_label 'hello'
+    #
+    # @example Display a label style with the "primary" appearance.
+    #   bh_label 'hello', context: :primary
+    def bh_label(text, options = {})
+      append_class! options, 'label'
+      context = context_for options.fetch(:context, nil), default: 'default', valid: %w(primary success info warning danger)
+      append_class! options, "label-#{context}"
+      content_tag :span, text, class: options[:class]
+    end
+
+  end
+end

--- a/lib/bh/middleman.rb
+++ b/lib/bh/middleman.rb
@@ -6,6 +6,7 @@ require 'bh/helpers/dropdown_helper'
 require 'bh/helpers/form_for_helper'
 require 'bh/helpers/glyphicon_helper'
 require 'bh/helpers/icon_helper'
+require 'bh/helpers/label_helper'
 require 'bh/helpers/link_to_helper'
 require 'bh/helpers/modal_helper'
 require 'bh/helpers/nav_helper'
@@ -25,6 +26,7 @@ module Bh
       include FormForHelper
       include GlyphiconHelper
       include IconHelper
+      include LabelHelper
       include LinkToHelper
       include ModalHelper
       include NavHelper

--- a/lib/bh/railtie.rb
+++ b/lib/bh/railtie.rb
@@ -6,6 +6,7 @@ require 'bh/helpers/dropdown_helper'
 require 'bh/helpers/form_for_helper'
 require 'bh/helpers/glyphicon_helper'
 require 'bh/helpers/icon_helper'
+require 'bh/helpers/label_helper'
 require 'bh/helpers/link_to_helper'
 require 'bh/helpers/modal_helper'
 require 'bh/helpers/nav_helper'
@@ -25,6 +26,7 @@ module Bh
       ActionView::Base.send :include, FormForHelper
       ActionView::Base.send :include, GlyphiconHelper
       ActionView::Base.send :include, IconHelper
+      ActionView::Base.send :include, LabelHelper
       ActionView::Base.send :include, LinkToHelper
       ActionView::Base.send :include, ModalHelper
       ActionView::Base.send :include, NavHelper

--- a/spec/helpers/label_helper_spec.rb
+++ b/spec/helpers/label_helper_spec.rb
@@ -1,0 +1,42 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+require 'bh/helpers/label_helper'
+include Bh::LabelHelper
+
+describe 'bh_label' do
+
+  it 'returns a Bootstrap label' do
+    expect(bh_label 'hello').to eq '<span class="label label-default">hello</span>'
+  end
+
+  context 'when specifying a valid :context' do
+    specify ':primary context' do
+      expect(bh_label 'hello', context: :primary).to eq '<span class="label label-primary">hello</span>'
+    end
+
+    specify ':success context' do
+      expect(bh_label 'hello', context: :success).to eq '<span class="label label-success">hello</span>'
+    end
+
+    specify ':info context' do
+      expect(bh_label 'hello', context: :info).to eq '<span class="label label-info">hello</span>'
+    end
+
+    specify ':warning context' do
+      expect(bh_label 'hello', context: :warning).to eq '<span class="label label-warning">hello</span>'
+    end
+
+    specify ':danger context' do
+      expect(bh_label 'hello', context: :danger).to eq '<span class="label label-danger">hello</span>'
+    end
+  end
+
+  context 'when specifying an invalid :context' do
+    it 'returns the default context' do
+      expect(bh_label 'hello', context: :foobar).to eq '<span class="label label-default">hello</span>'
+    end
+  end
+
+end


### PR DESCRIPTION
This PR implements a helper method for generating a Bootstrap label: http://getbootstrap.com/components/#labels

I didn't realize until after I had finished that [Rails already has a helper method called `label`](http://apidock.com/rails/ActionView/Helpers/FormHelper/label). The weird thing is that it should only be available in the context of `form_for`:

``` text
<%= form_for :person do |f| %>
  <%= f.label :name %>
  <%= f.text_field :name %>
<% end %>
```

The alternative, which can be used outside of `form_for` is supposed to be `label_tag`, so I don't know why`label` is bleeding into the global scope.

Anyway, I just decided to prefix the helper name with `bh`. What do you think?
