### PR TITLE
Ability to add as: :button to link_to.

### DIFF
--- a/lib/bh/helpers/link_to_helper.rb
+++ b/lib/bh/helpers/link_to_helper.rb
@@ -1,8 +1,10 @@
 require 'bh/helpers/base_helper'
+require 'bh/helpers/button_helper'
 
 module Bh
   module LinkToHelper
     include BaseHelper
+    include ButtonHelper
 
     # Overrides ActionView +link_to+ to be able to add the 'alert-link' class
     # to the link in case the link is inside of an alert.
@@ -11,7 +13,17 @@ module Bh
     # '<li>' item in case the link is inside of a nav.
     # Overrides ActionView +link_to+ to be able to add the 'navbar-brand'
     # class to the link in case the link is inside of an alert.
+    # Overrides ActionView +link_to+ to be able to add button classes
+    # to the link if as: :button is passed as options.
+    # @example link_to as button
+    #    link_to 'Some link', '#', as: :button, context: :info, size: :lg
     def link_to(*args, &block)
+      options = (block_given? ? args[1] : args[2]) || {}
+      case options.delete(:as).to_s
+      when 'button', 'btn'
+        add_link_class!(btn_class(options), *args, &block)
+      end
+
       if @alert_link
         super *add_link_class!('alert-link', *args, &block), &block
       elsif @navbar_vertical

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -41,6 +41,24 @@ describe 'link_to' do
       expect(link).not_to include '<li>'
     end
 
+    specify 'by default, does not add button classes to link' do
+      expect(link).not_to include 'btn'
+    end
+
+    context 'as button' do
+      specify 'given as button option, adds default button classes' do
+        expect(link_to 'Home', url, as: :button).to include 'btn btn-default'
+      end
+
+      specify 'given btn size, adds size class link' do
+        expect(link_to 'Home', url, as: :button, size: :lg).to include 'btn-lg'
+      end
+
+      specify 'given btn context, adds context class link' do
+        expect(link_to 'Home', url, as: :button, context: :danger).to include 'btn btn-danger'
+      end
+    end
+
     context 'inside a nav' do
       let(:html) { nav { link } }
 
@@ -91,6 +109,34 @@ describe 'link_to' do
 
     specify 'by default, does not surround the link in a list item' do
       expect(link).not_to include '<li>'
+    end
+
+
+    context 'as button' do
+      specify 'given as button option, adds default button classes' do
+        link = link_to url, as: :button do
+          'Home'
+        end
+        expect(link).to include 'btn btn-default'
+      end
+
+      specify 'inside an alert, applies the "btn" class' do
+        expect(alert_box { link_to(url, as: :btn) { 'Home' } }).to include 'btn'
+      end
+
+      specify 'given btn size, adds size class link' do
+        link = link_to url, as: :button, size: :lg do
+          'Home'
+        end
+        expect(link).to include 'btn-lg'
+      end
+
+      specify 'given btn context, adds context class link' do
+        link = link_to url, as: :button, context: :danger do
+          'Home'
+        end
+        expect(link).to include 'btn btn-danger'
+      end
     end
 
     context 'inside a nav' do


### PR DESCRIPTION
Added `as: :button` option to `link_to` helper. 

Example usage: 

``` ruby
link_to 'Home', url, as: :button, size: :lg, context: :info

link_to url, as: :button, size: :lg, context: :info do
  'Home'
end
```
