### PR TITLE
Wrap the content of `panel` in "panel-body"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about changelogs, check
 
 ## 1.1.2 - unreleased
 
+* [ENHANCEMENT] Wrap plain content passed to `panel` inside the panel body
 * [ENHANCEMENT] Allow `dropdown` to display a full-width button when called with `{layout: :block, groupable: false}`
 * [ENHANCEMENT] Allow `alert_box` to pass extra parameters to the alert box <div>
 

--- a/examples/middleman/source/index.html.erb
+++ b/examples/middleman/source/index.html.erb
@@ -24,6 +24,11 @@
 
       <h1>Panels</h1>
 
+      <%= panel 'Content only' %>
+      <%= panel title: 'Title only' %>
+      <%= panel body: 'Body only' %>
+      <%= panel 'Content', body: 'And Body', title: 'and title' %>
+
       <%= panel body: 'You accepted the Terms of service.', title: 'Thanks', context: :primary %>
       <%= panel body: 'You accepted the Terms of service.', title: 'Thanks', context: :success %>
       <%= panel body: 'You accepted the Terms of service.', title: 'Thanks', context: :info %>

--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -23,6 +23,15 @@
 
       <h1>Panels</h1>
 
+      <%= panel do %>
+        Block only
+      <% end %>
+
+      <%= panel 'Content only' %>
+      <%= panel title: 'Title only' %>
+      <%= panel body: 'Body only' %>
+      <%= panel 'Content', body: 'And Body', title: 'and title' %>
+
       <%= panel body: 'You accepted the Terms of service.', title: 'Thanks', context: :primary %>
       <%= panel body: 'You accepted the Terms of service.', title: 'Thanks', context: :success %>
       <%= panel body: 'You accepted the Terms of service.', title: 'Thanks', context: :info %>

--- a/lib/bh/helpers/panel_helper.rb
+++ b/lib/bh/helpers/panel_helper.rb
@@ -1,54 +1,47 @@
 require 'bh/helpers/base_helper'
 
 module Bh
-  # Provides methods to include panels.
-  # @see http://getbootstrap.com/components/#panels
+  # Provides the `panel` helper.
   module PanelHelper
     include BaseHelper
 
-    # Returns an HTML block tag that follows the Bootstrap documentation
-    # on how to display *panels*.
-    #
-    # The content of the panel can either be passed as the first parameter (in
-    # which case, the options are the second parameter), or as a block (in
-    # which case, the options are the first paramter).
-    # @example An panel with plain-text content passed as the first parameter.
-    #   panel 'Your profile was updated!', context: :info, title: 'Profile'
-    # @example A panel with HTML content passed as a block.
-    #   panel context: :info, title: 'Profile'
-    #     content_tag :strong, "Your profile was updated!"
-    #   end
-    #
-    # @return [String] an HTML block tag for a panel.
-    # @param [String] content_or_options_with_block the content to display in
-    #   the panel.
-    # @param [Hash] options the display options for the panel.
-    # @option options [#to_s] :context (:default) the contextual alternative to
-    #   apply to the panel depending on its importance. Can be :default,
-    #   :primary, :success, :info, :warning  or :danger.
-    # @option options [#to_s] :body if present, the panel will include the
-    #   provided text wrapped in a 'panel-body' block, for proper padding
-    # @see http://getbootstrap.com/components/#panels-basic
-    # @option options [#to_s] :heading if present, the panel will include a
-    #   heading with the provided text.
-    # @option options [#to_s] :title if present, the panel will include a
-    #   heading with the provided text wrapped in a 'panel-title' block, for
-    #   proper title styling and link coloring.
-    # @option options [#to_s] :tag (:div) the HTML tag to wrap the panel in.
-    # @see http://getbootstrap.com/components/#panels-heading
+    # @see http://getbootstrap.com/components/#panels
+    # @return [String] an HTML block to display a panel.
+    # @overload panel(content, options = {})
+    #   @example An informative panel with plain-text content.
+    #   panel body: 'You accepted the Terms of service.', context: :success
+    #   @param [#to_s] content the main text to include in the panel.
+    #   @param [Hash] options the display options for the panel.
+    #   @option options [#to_s] :body the main text to include in the panel.
+    #     Using this option is equivalent to using the `content` parameter;
+    #     in case both are used, the `content` takes precedence.
+    #   @option options [#to_s] :heading the text to include above the body.
+    #   @option options [#to_s] :title the text to include above the body,
+    #     formatted for more impact than a simple heading.
+    #   @option options [#to_s] :context (#to_s) (:default) the contextual
+    #     alternative to apply to the panel heading and border. Can be
+    #     `:danger`, `:info`, `:primary`, `:success` or `:warning`.
+    #   @option options [#to_s] :tag (#to_s) (:div) the HTML tag to wrap the
+    #     panel into.
+    # @overload panel(options = {}, &content_block)
+    #   @example An informative panel with HTML content.
+    #   panel context: :success do
+    #     content_tag :div, class: 'panel-body' do
+    #       content_tag :strong, 'You accepted the Terms of service.'
+    #   @yieldreturn [#to_s] the content of the panel.
     def panel(content_or_options_with_block = nil, options = nil, &block)
       if block_given?
-        panel_string capture(&block), content_or_options_with_block || {}
+        panel_string capture(&block), (content_or_options_with_block || {})
       elsif content_or_options_with_block.is_a?(Hash) && options.nil?
         panel_string nil, content_or_options_with_block
       else
-        panel_string content_or_options_with_block, options || {}
+        panel_string nil, (options || {}).merge(body: content_or_options_with_block)
       end
     end
 
   private
 
-    def panel_string(content = nil, options = {})
+    def panel_string(content, options = {})
       content = prepend_optional_body_to content, options
       content = prepend_optional_heading_to content, options
       tag = options.fetch :tag, :div

--- a/spec/helpers/panel_helper_spec.rb
+++ b/spec/helpers/panel_helper_spec.rb
@@ -64,8 +64,20 @@ describe 'panel' do
   end
 
   describe 'with the :body option' do
-    specify 'includes its value in the panel body' do
-      expect(panel 'content', body: 'Your profile was updated', title: 'Profile').to include '<div class="panel-body">Your profile was updated</div>'
+    specify 'and no content, includes its value in the panel body' do
+      expect(panel body: 'Your profile was updated', title: 'Profile').to include '<div class="panel-body">Your profile was updated</div>'
+    end
+
+    specify 'and content, uses the content as the body' do
+      expect(panel 'content', body: 'Your profile was updated', title: 'Profile').to include '<div class="panel-body">content</div>'
+    end
+
+    specify 'not set and with content, uses the content as the body' do
+      expect(panel 'content', title: 'Profile').to include '<div class="panel-body">content</div>'
+    end
+
+    specify 'not set and with a content, does not include a body' do
+      expect(title: 'Profile').not_to include '<div class="panel-body">'
     end
   end
 


### PR DESCRIPTION
Before this commit, the following code was valid:

``` rhtml
<%= panel 'Content' %>
```

but resulted in an the following _ugly_ panel:

![ugly](https://cloud.githubusercontent.com/assets/7408595/4946816/afa9dc8c-6619-11e4-897c-0cc2ecc39a7a.png)

After this commit, plain-text content passed to `panel` will instead be
wrapped in a `<div class="panel-body">`, and will look like:

![nice](https://cloud.githubusercontent.com/assets/7408595/4946817/afaa1d0a-6619-11e4-9899-2b0a5cc9a378.png)

This is exactly the same as passing the content in the `:body` option:

``` rhtml
<%= panel body: 'Content' %>
```

In case body content and `:body` options are passed, the first takes precedence.
