### PR TITLE
Pass `panel` extra params to the wrapping <div>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about changelogs, check
 
 ## 1.1.2 - unreleased
 
+* [ENHANCEMENT] Allow `panel` to pass extra parameters to the wrapping <div>
 * [ENHANCEMENT] Wrap plain content passed to `panel` inside the panel body
 * [ENHANCEMENT] Allow `dropdown` to display a full-width button when called with `{layout: :block, groupable: false}`
 * [ENHANCEMENT] Allow `alert_box` to pass extra parameters to the alert box <div>

--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -31,6 +31,8 @@
       <%= panel title: 'Title only' %>
       <%= panel body: 'Body only' %>
       <%= panel 'Content', body: 'And Body', title: 'and title' %>
+      <%= panel 'With extra params', class: 'important', id: 'alert', data: {name: 'name'} %>
+
 
       <%= panel body: 'You accepted the Terms of service.', title: 'Thanks', context: :primary %>
       <%= panel body: 'You accepted the Terms of service.', title: 'Thanks', context: :success %>

--- a/lib/bh/classes/panel.rb
+++ b/lib/bh/classes/panel.rb
@@ -1,0 +1,72 @@
+require 'bh/classes/base'
+
+module Bh
+  module Classes
+    class Panel < Base
+      # Differently from other classes, Panel works with no content or block,
+      # given that the options[:body] is passed, in which case it functions
+      # as the content.
+      def initialize(app = nil, *args, &block)
+        if args.first.is_a?(Hash) && !block_given?
+          args.unshift args.first.delete(:body)
+        end
+
+        super
+      end
+
+      # @return [#to_s] the content-related class to assign to the alert box.
+      def context_class
+        contexts[@options[:context]]
+      end
+
+      # @return [#to_s] the HTML tag to wrap the panel in.
+      def tag
+        @options.fetch :tag, :div
+      end
+
+      # @return [#to_s] the text to display as the panel header
+      def heading
+        text = title || @options[:heading]
+        @app.content_tag :div, text, class: 'panel-heading' if text
+      end
+
+      def merge_html!(html)
+        @content ||= html
+      end
+
+      # @return [Hash<Symbol, String>] the class that Bootstrap requires to
+      #   append to an panel box based on its context.
+      def contexts
+        HashWithIndifferentAccess.new(:'panel-default').tap do |klass|
+          klass[:primary]   = :'panel-primary'
+          klass[:success] = :'panel-success'
+          klass[:info]    = :'panel-info'
+          klass[:warning] = :'panel-warning'
+          klass[:danger]  = :'panel-danger'
+        end
+      end
+
+      def body
+        if @options[:body]
+          @app.content_tag :div, @options[:body], class: 'panel-body'
+        end
+      end
+
+    private
+
+      def extract_content_from(*args, &block)
+        if block_given?
+          super
+        else
+          @app.content_tag :div, super, class: 'panel-body'
+        end
+      end
+
+      def title
+        if @options[:title]
+          @app.content_tag :h3, @options[:title], class: 'panel-title'
+        end
+      end
+    end
+  end
+end

--- a/lib/bh/helpers/panel_helper.rb
+++ b/lib/bh/helpers/panel_helper.rb
@@ -1,20 +1,15 @@
-require 'bh/helpers/base_helper'
+require 'bh/classes/panel'
 
 module Bh
   # Provides the `panel` helper.
   module PanelHelper
-    include BaseHelper
-
     # @see http://getbootstrap.com/components/#panels
     # @return [String] an HTML block to display a panel.
-    # @overload panel(content, options = {})
+    # @overload panel(options = {})
     #   @example An informative panel with plain-text content.
     #   panel body: 'You accepted the Terms of service.', context: :success
-    #   @param [#to_s] content the main text to include in the panel.
     #   @param [Hash] options the display options for the panel.
     #   @option options [#to_s] :body the main text to include in the panel.
-    #     Using this option is equivalent to using the `content` parameter;
-    #     in case both are used, the `content` takes precedence.
     #   @option options [#to_s] :heading the text to include above the body.
     #   @option options [#to_s] :title the text to include above the body,
     #     formatted for more impact than a simple heading.
@@ -29,45 +24,15 @@ module Bh
     #     content_tag :div, class: 'panel-body' do
     #       content_tag :strong, 'You accepted the Terms of service.'
     #   @yieldreturn [#to_s] the content of the panel.
-    def panel(content_or_options_with_block = nil, options = nil, &block)
-      if block_given?
-        panel_string capture(&block), (content_or_options_with_block || {})
-      elsif content_or_options_with_block.is_a?(Hash) && options.nil?
-        panel_string nil, content_or_options_with_block
-      else
-        panel_string nil, (options || {}).merge(body: content_or_options_with_block)
-      end
-    end
+    def panel(*args, &block)
+      panel = Bh::Panel.new self, *args, &block
+      panel.extract! :body, :context, :title, :heading, :tag
 
-  private
-
-    def panel_string(content, options = {})
-      content = prepend_optional_body_to content, options
-      content = prepend_optional_heading_to content, options
-      tag = options.fetch :tag, :div
-      content_tag tag, content, class: panel_class(options[:context])
-    end
-
-    def panel_class(context = nil)
-      valid_contexts = %w(primary success info warning danger)
-      context = context_for context, valid: valid_contexts
-      "panel panel-#{context}"
-    end
-
-    def prepend_optional_body_to(content, options = {})
-      body = options[:body]
-      body = content_tag :div, body, class: 'panel-body' if body
-      safe_join [body, content].compact
-    end
-
-    def prepend_optional_heading_to(content, options = {})
-      title = if options[:title]
-        content_tag :h3, options[:title], class: 'panel-title'
-      elsif options[:heading]
-        options[:heading]
-      end
-      heading = content_tag :div, title, class: 'panel-heading' if title
-      safe_join [heading, content].compact
+      panel.append_class! :panel
+      panel.append_class! panel.context_class
+      panel.merge_html! panel.body
+      panel.prepend_html! panel.heading
+      panel.render_tag panel.tag
     end
   end
 end

--- a/spec/helpers/panel_helper_spec.rb
+++ b/spec/helpers/panel_helper_spec.rb
@@ -5,6 +5,8 @@ require 'bh/helpers/panel_helper'
 include Bh::PanelHelper
 
 describe 'panel' do
+  attr_accessor :output_buffer
+
   describe 'accepts as parameters:' do
     let(:behave) { include 'content' }
 
@@ -102,6 +104,12 @@ describe 'panel' do
   describe 'with the :tag option' do
     specify 'uses the specified tag rather than DIV' do
       expect(panel 'content', tag: :aside).to include '<aside class="panel panel-default">'
+    end
+  end
+
+  describe 'with extra options' do
+    specify 'pass the options to the wrapping DIV' do
+      expect(panel 'content', id: 'my-panel', data: {name: 'a-panel'}).to include '<div class="panel panel-default" data-name="a-panel" id="my-panel">'
     end
   end
 end


### PR DESCRIPTION
Before this commit, the `panel` helper ignored unknown options.
For instance the code:

``` rhtml
<%= panel 'content', class: 'important', id: 'alert', data: {name: 'name'} %>
```

would simply generate the following HTML

``` html
<div class="panel panel-default">
  <div class="panel-body">With extra params</div>
</div>
```

ignoring the `:class`, `:data` and `:id` parameter.
After this commit, the result is:

``` html
<div class="important panel panel-default" id="alert" data-name="name">
  <div class="panel-body">With extra params</div>
</div>
```

which should partially mitigate #39.

---

This commit also reduces public API methods from PanelHelper

Before this PR, including `bh` in an app would include more methods
than necessary for panels: methods like `panel_string` or
`panel_class`, that should only be accessed privately.

This PR extracts those private methods into a new Button class
that includes all the business logic to render elements and edit
attributes (e.g., attach classes), leaving the helper cleaner.
