### PR TITLE
Reduce public API methods from PanelRowHelper

### DIFF
--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -48,9 +48,9 @@
       <h1>Panel rows</h1>
 
       <%= panel_row column_class: 'col-sm-4' do %>
-        <%= panel body: 'Panel #1' %>
+        <%= panel 'Panel #1' %>
         <%= panel body: 'Panel #2' %>
-        <%= panel body: 'Panel #3' %>
+        <%= panel { content_tag :div, 'Panel #3', class: 'panel-body' } %>
       <% end %>
 
       <%= panel_row column_class: 'col-sm-4' do %>

--- a/lib/bh/classes/panel.rb
+++ b/lib/bh/classes/panel.rb
@@ -14,7 +14,7 @@ module Bh
         super
       end
 
-      # @return [#to_s] the content-related class to assign to the alert box.
+      # @return [#to_s] the content-related class to assign to the panel.
       def context_class
         contexts[@options[:context]]
       end

--- a/lib/bh/classes/panel_row.rb
+++ b/lib/bh/classes/panel_row.rb
@@ -1,0 +1,13 @@
+require 'bh/classes/base'
+
+module Bh
+  module Classes
+    class PanelRow < Base
+      # @return [#to_s] the grid-related class to assign to each panel
+      #   nested in this panel row.
+      def column_class
+        @options[:column_class]
+      end
+    end
+  end
+end

--- a/lib/bh/helpers/panel_helper.rb
+++ b/lib/bh/helpers/panel_helper.rb
@@ -32,7 +32,13 @@ module Bh
       panel.append_class! panel.context_class
       panel.merge_html! panel.body
       panel.prepend_html! panel.heading
-      panel.render_tag panel.tag
+      html = panel.render_tag panel.tag
+
+      if panel_row = Bh::Stack.find(Bh::PanelRow)
+        content_tag :div, html, class: panel_row.column_class
+      else
+        html
+      end
     end
   end
 end

--- a/lib/bh/helpers/panel_row_helper.rb
+++ b/lib/bh/helpers/panel_row_helper.rb
@@ -1,46 +1,27 @@
-require 'bh/helpers/panel_helper'
+require 'bh/classes/panel_row'
 
 module Bh
-  # Provides methods to include multiple panels in a row.
-  # @see http://getbootstrap.com/css/#grid
-  # @see http://getbootstrap.com/components/#panels
+  # Provides the `panel_row` helper.
   module PanelRowHelper
-    include PanelHelper # for panel
-
-    # Returns an HTML block tag that follows the Bootstrap documentation
-    # on how to display a *row*, passing column options to each panel in
-    # the row.
-    #
-    # @return [String] an HTML block tag for a row of panels.
-    # @param [Hash] options the display options for the row of panels.
-    # @option options [#to_s] :column_class the class to apply to the column
-    #   <div> that wraps every panel in the row. Useful to specify a grid size
-    #   for the column such as 'col-sm-4' to indicate how many columns of the
-    #   row each panel should occupy.
-    # @see http://getbootstrap.com/css/#grid
     # @see http://getbootstrap.com/components/#panels
-    def panel_row(options = {}, &block)
-      content_tag :div, class: 'row' do
-        capture_panel_row(options, &block) if block_given?
-      end
-    end
+    # @see http://getbootstrap.com/css/#grid
+    # @return [String] an HTML block to display a row of panels.
+    # @example An row of 3 panels with the same width.
+    #   panel_row column_class: 'col-sm-4' do
+    #     panel body: 'Panel #1'
+    #     panel body: 'Panel #2'
+    #     panel body: 'Panel #3'
+    # @param [Hash] options the display options for the row of panels.
+    # @option options [#to_s] :column_class the class to wrap each panel with.
+    #   Useful to specify a grid size for the column such as 'col-sm-4' to
+    #   indicate how many columns of the row each panel should occupy.
+    # @yieldreturn [#to_s] the panels to display in a row.
+    def panel_row(*args, &block)
+      panel_row = Bh::PanelRow.new self, *args, &block
+      panel_row.extract! :column_class
 
-  private
-
-    # Overrides PanelHelper +panel+ to be able to add a column <div> around
-    # each panel in a row, to make it fit inside the panel row.
-    def panel(*args, &block)
-      panel = super *args, &block
-      if @panel_column_class
-        content_tag :div, panel, class: @panel_column_class
-      else
-        panel
-      end
-    end
-
-    def capture_panel_row(options = {}, &block)
-      @panel_column_class = options[:column_class]
-      capture(&block).tap{ @panel_column_class = nil }
+      panel_row.append_class! :row
+      panel_row.render_tag :div
     end
   end
 end

--- a/spec/helpers/panel_row_helper_spec.rb
+++ b/spec/helpers/panel_row_helper_spec.rb
@@ -2,9 +2,13 @@
 
 require 'spec_helper'
 require 'bh/helpers/panel_row_helper'
+require 'bh/helpers/panel_helper'
 include Bh::PanelRowHelper
+include Bh::PanelHelper
 
 describe 'panel_row' do
+  attr_accessor :output_buffer
+
   describe 'without a block' do
     specify 'shows an empty row' do
       expect(panel_row).to include '<div class="row">'
@@ -20,7 +24,7 @@ describe 'panel_row' do
 
     describe 'that includes panels and the :column_class option' do
       specify 'wraps each panel in a column <div> with the given class' do
-        expect(panel_row(column_class: 'col-sm-12') { panel body: 'content' }).to include '<div class="col-sm-12">'
+        expect(panel_row(column_class: 'col-sm-12') { panel 'content' }).to include '<div class="row"><div class="col-sm-12">'
       end
     end
   end


### PR DESCRIPTION
Before this PR, including `bh` in an app would include more methods
than necessary for panel rows: methods like `capture_panel_row` that
should only be accessed privately.

This PR extracts those private methods into a new Button class
that includes all the business logic to render elements and edit
attributes (e.g., attach classes), leaving the helper cleaner.
