### PR TITLE
Reduce public API methods from CdnHelper

### DIFF
--- a/lib/bh/classes/cdn.rb
+++ b/lib/bh/classes/cdn.rb
@@ -1,0 +1,34 @@
+require 'bh/classes/base'
+
+module Bh
+  module Classes
+    class Cdn
+      # @note if unspecified, the version should match the latest available
+      #   version. If that's not the case, it's a bug and should be fixed.
+      def self.bootstrap(options = {})
+        options[:version] ||= '3.3.0'
+        cdn_asset options.merge(library: 'bootstrap')
+      end
+
+      # @note if unspecified, the version should match the latest available
+      #   version. If that's not the case, it's a bug and should be fixed.
+      def self.font_awesome(options = {})
+        options[:version] ||= '4.2.0'
+        cdn_asset options.merge(library: 'font-awesome')
+      end
+
+    private
+
+      def self.cdn_asset(options = {})
+        version = options[:version]
+        extension = options[:extension]
+        name = options[:name]
+        name = "#{name}.min" if options.fetch(:minified, true)
+        library = options[:library]
+        scheme = "#{options[:scheme]}:" if options[:scheme]
+        host = "#{scheme}//netdna.bootstrapcdn.com"
+        "#{host}/#{library}/#{version}/#{extension}/#{name}.#{extension}"
+      end
+    end
+  end
+end

--- a/lib/bh/helpers/cdn_helper.rb
+++ b/lib/bh/helpers/cdn_helper.rb
@@ -1,3 +1,5 @@
+require 'bh/classes/cdn'
+
 module Bh
   # Provides methods to retrieve the URLs of Bootstrap stylesheets and
   # Javascript files from Bootstrap CDN
@@ -9,7 +11,7 @@ module Bh
     # @option options [String] :scheme the URI scheme to use.
     # @option options [Boolean] :minified whether to use the minified version.
     def bootstrap_css(options = {})
-      bootstrap_asset options.merge(name: 'bootstrap', extension: 'css')
+      Bh::Cdn.bootstrap options.merge(name: 'bootstrap', extension: 'css')
     end
 
     # @return [String] the URL of the Bootstrap Theme CSS file
@@ -18,7 +20,7 @@ module Bh
     # @option options [String] :scheme the URI scheme to use.
     # @option options [Boolean] :minified whether to use the minified version.
     def bootstrap_theme_css(options = {})
-      bootstrap_asset options.merge(name: 'bootstrap-theme', extension: 'css')
+      Bh::Cdn.bootstrap options.merge(name: 'bootstrap-theme', extension: 'css')
     end
 
     # @return [String] the URL of the Font Awesome CSS file
@@ -28,7 +30,7 @@ module Bh
     # @option options [Boolean] :minified whether to use the minified version.
     # @see http://fontawesome.io/get-started/
     def font_awesome_css(options = {})
-      font_awesome_asset options.merge(name: 'font-awesome', extension: 'css')
+      Bh::Cdn.font_awesome options.merge(name: 'font-awesome', extension: 'css')
     end
 
     # @return [String] the URL of the Bootstrap JS file
@@ -37,34 +39,7 @@ module Bh
     # @option options [String] :scheme the URI scheme to use.
     # @option options [Boolean] :minified whether to use the minified version.
     def bootstrap_js(options = {})
-      bootstrap_asset options.merge(name: 'bootstrap', extension: 'js')
-    end
-
-  private
-
-    # @note if unspecified, the version should match the latest available
-    #   version. If that's not the case, it's a bug and should be fixed.
-    def bootstrap_asset(options = {})
-      options[:version] ||= '3.3.0'
-      cdn_asset options.merge(library: 'bootstrap')
-    end
-
-    # @note if unspecified, the version should match the latest available
-    #   version. If that's not the case, it's a bug and should be fixed.
-    def font_awesome_asset(options = {})
-      options[:version] ||= '4.2.0'
-      cdn_asset options.merge(library: 'font-awesome')
-    end
-
-    def cdn_asset(options = {})
-      version = options[:version]
-      extension = options[:extension]
-      name = options[:name]
-      library = options[:library]
-      name = "#{name}.min" if options.fetch(:minified, true)
-      scheme = "#{options[:scheme]}:" if options[:scheme]
-      host = '//netdna.bootstrapcdn.com'
-      "#{scheme}#{host}/#{library}/#{version}/#{extension}/#{name}.#{extension}"
+      Bh::Cdn.bootstrap options.merge(name: 'bootstrap', extension: 'js')
     end
   end
 end


### PR DESCRIPTION
Before this PR, including `bh` in an app would include more methods
than necessary for CDN helpers: methods like `bootstrap_asset` or
`cdn_asset`, that should only be accessed privately.

This PR extracts those private methods into a new Cdn class
that includes all the business logic to render elements and edit
attributes (e.g., attach classes), leaving the helper cleaner.
