### PR TITLE
Reduce public API methods from IconHelper

### DIFF
--- a/examples/middleman/source/index.html.erb
+++ b/examples/middleman/source/index.html.erb
@@ -87,15 +87,19 @@
       <%= progress_bar percentage: 30, animated: true %>
       <%= progress_bar [{percentage: 30, context: :success, label: 'Completed'}, {percentage: 40, context: :warning, animated: true, label: 'Pending'}] %>
 
+
       <h1>Glyphicons</h1>
 
-      <%= icon :zoom_in %>
+      <%= glyphicon :zoom_in %>
+      <%= glyphicon %>
 
       <h1>Icons</h1>
 
       <%= icon :heart %>
-      <%= stylesheet_link_tag font_awesome_css %>
-      <%= icon :heart, library: :font_awesome, class: 'fa-5x' %>
+      <%= icon :heart, library: :glyphicons %>
+      <%= icon :heart, library: :font_awesome %>
+      <%= icon :heart, library: :font_awesome, class: 'fa-fw' %>
+      <%= icon :heart, library: :font_awesome, class: 'fa-lg' %>
 
     </div>
     <%= javascript_include_tag '//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js' %>

--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -257,13 +257,16 @@
 
       <h1>Glyphicons</h1>
 
-      <%= icon :zoom_in %>
+      <%= glyphicon :zoom_in %>
+      <%= glyphicon %>
 
       <h1>Icons</h1>
 
       <%= icon :heart %>
-      <%= stylesheet_link_tag font_awesome_css %>
-      <%= icon :heart, library: :font_awesome, class: 'fa-5x' %>
+      <%= icon :heart, library: :glyphicons %>
+      <%= icon :heart, library: :font_awesome %>
+      <%= icon :heart, library: :font_awesome, class: 'fa-fw' %>
+      <%= icon :heart, library: :font_awesome, class: 'fa-lg' %>
 
     </div>
     <%= javascript_include_tag '//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js' %>

--- a/lib/bh/classes/icon.rb
+++ b/lib/bh/classes/icon.rb
@@ -1,0 +1,32 @@
+require 'bh/classes/base'
+
+module Bh
+  module Classes
+    class Icon < Base
+      # @return [#to_s] the class to assign to the icon based on the Vector
+      #   Icon library used.
+      def library_class
+        libraries[@options[:library].to_s.underscore] || @options[:library]
+      end
+
+      # @return [#to_s] the class to assign to the icon based on the name
+      #   of the icon.
+      def name_class
+        if name = @options[:name]
+          "#{library_class}-#{name.to_s.gsub '_', '-'}" 
+        end
+      end
+
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to icons for each possible vector icon library.
+      def libraries
+        HashWithIndifferentAccess.new(nil).tap do |klass|
+          klass[:font_awesome]  = :'fa'
+          klass[:glyphicons]    = :'glyphicon'
+          klass[:'']            = :'glyphicon'
+        end
+      end
+    end
+  end
+end

--- a/lib/bh/helpers/glyphicon_helper.rb
+++ b/lib/bh/helpers/glyphicon_helper.rb
@@ -1,14 +1,11 @@
 require 'bh/helpers/icon_helper'
 
 module Bh
-  # Provides methods to include Glyphicons.
-  # @see http://getbootstrap.com/components/#glyphicons
+  # Provides the `glyphicon` helper.
   module GlyphiconHelper
     include IconHelper
-
-    # Returns an HTML block tag that follows the Bootstrap documentation
-    # on how to display *glyphicons*.
-    # @return [String] an HTML block tag for a glyphicon.
+    # @see http://getbootstrap.com/components/#glyphicons
+    # @return [String] an HTML block to display an glyphicon.
     # @param [#to_s] name the name of the icon to display, with either dashes
     #   or underscores to separate multiple words.
     # @param [Hash] options the options passed to the HTML tag that displays

--- a/lib/bh/helpers/icon_helper.rb
+++ b/lib/bh/helpers/icon_helper.rb
@@ -1,41 +1,44 @@
-require 'bh/helpers/base_helper'
+require 'bh/classes/icon'
 
 module Bh
-  # Provides methods to include vector icons from different libraries.
-  # @see http://getbootstrap.com/components/#glyphicons
-  # @see http://fortawesome.github.io/Font-Awesome/examples/#bootstrap
+  # Provides the `icon` helper.
   module IconHelper
-    include BaseHelper
-
-    # Returns an HTML block tag to display a vector icon.
-    # @return [String] an HTML block tag for a vector icon.
+    # @see http://getbootstrap.com/components/#glyphicons
+    # @see http://fortawesome.github.io/Font-Awesome/examples/#bootstrap
+    # @return [String] an HTML block to display a vector (font) icon.
     # @param [#to_s] name the name of the icon to display, with either dashes
     #   or underscores to separate multiple words.
-    # @param [Hash] options the options for the icon tag. The following options
-    #   are used by the +icon+ method, while the remaining ones are passed
-    #   to the HTML tag that displays the icon.
+    # @param [Hash] options the options for the icon tag.
     # @option options [#to_s] :library (:glyphicons) the vector icon library
     #   to use. Valid values are 'glyphicon', 'glyphicons' (for Glyphicons),
     #   'font-awesome', 'font_awesome' and 'fa' (for Font Awesome).
-    # @example Display the "zoom in" glyphicon
-    #   icon :zoom_in
+    # @example Display the "zoom in" glyphicon with a title
+    #   icon :zoom_in, title: 'Zoom'
     # @example Display the "fire" font awesome icon
     #   icon 'fire', library: :font_awesome
     def icon(name = nil, options = {})
-      prefix = library_prefix_for options.delete(:library)
-      append_class! options, prefix
-      append_class! options, "#{prefix}-#{name.to_s.gsub '_', '-'}" if name
-      content_tag :span, nil, options
+      icon = Bh::Icon.new self, nil, options.merge(name: name)
+      icon.extract! :library, :name
+
+      icon.append_class! icon.library_class
+      icon.append_class! icon.name_class
+      icon.render_tag :span
+
+
+      # prefix = library_prefix_for options.delete(:library)
+      # append_class! options, prefix
+      # append_class! options, "#{prefix}-#{name.to_s.gsub '_', '-'}" if name
+      # content_tag :span, nil, options
     end
 
-  private
-
-    def library_prefix_for(name)
-      case name.to_s.underscore
-        when 'font_awesome' then :fa
-        when '', 'glyphicons' then :glyphicon
-        else name
-      end
-    end
+  # private
+  #
+  #   def library_prefix_for(name)
+  #     case name.to_s.underscore
+  #       when 'font_awesome' then :fa
+  #       when '', 'glyphicons' then :glyphicon
+  #       else name
+  #     end
+  #   end
   end
 end


### PR DESCRIPTION
Before this PR, including `bh` in an app would include more methods
than necessary for icon helpers: methods like `library_prefix_for`
that should only be accessed privately.

This PR extracts those private methods into a new Icon class
that includes all the business logic to render elements and edit
attributes (e.g., attach classes), leaving the helper cleaner.
