### PR TITLE
Wrap the content of `modal` in "modal-body"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about changelogs, check
 
 ## 1.1.2 - unreleased
 
+* [ENHANCEMENT] Wrap plain content passed to `modal` inside the modal body
 * [ENHANCEMENT] Allow `panel` to pass extra parameters to the wrapping <div>
 * [ENHANCEMENT] Wrap plain content passed to `panel` inside the panel body
 * [ENHANCEMENT] Allow `dropdown` to display a full-width button when called with `{layout: :block, groupable: false}`

--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -67,6 +67,15 @@
 
       <h1>Modals</h1>
 
+      <%= modal do %>
+        Block only
+      <% end %>
+
+      <%= modal 'Content only' %>
+      <%= modal title: 'Title only' %>
+      <%= modal body: 'Body only' %>
+      <%= modal 'Content', body: 'And Body', title: 'and title' %>
+
       <%= modal body: 'Do what you want!' %>
       <%= modal body: 'Do what you want!', size: 'small' %>
       <%= modal title: 'Terms of service', body: 'Do what you want!', button: {context: :info}  %>

--- a/lib/bh/helpers/modal_helper.rb
+++ b/lib/bh/helpers/modal_helper.rb
@@ -35,18 +35,17 @@ module Bh
     # @see http://getbootstrap.com/javascript/#modals
     def modal(content_or_options_with_block = nil, options = nil, &block)
       if block_given?
-        modal_string content_or_options_with_block, &block
+        modal_string (content_or_options_with_block || {}), &block
       elsif content_or_options_with_block.is_a?(Hash) && options.nil?
         modal_string content_or_options_with_block, &Proc.new { nil }
       else
-        modal_string options, &Proc.new { content_or_options_with_block }
+        modal_string (options || {}).merge(body: content_or_options_with_block), &Proc.new { nil }
       end
     end
 
   private
 
-    def modal_string(options = nil, &block)
-      options ||= {}
+    def modal_string(options, &block)
       options[:id] ||= "modal-#{rand 10**10}"
       options[:title] ||= 'Modal'
       options[:body] = modal_body options[:body]

--- a/spec/helpers/modal_helper_spec.rb
+++ b/spec/helpers/modal_helper_spec.rb
@@ -120,8 +120,20 @@ describe 'modal' do
   end
 
   describe 'with the :body option' do
-    specify 'includes its value in the modal body' do
+    specify 'and no content, includes its value in the modal body' do
       expect(modal body: 'Your profile was updated', title: 'Profile').to include '<div class="modal-body">Your profile was updated</div>'
+    end
+
+    specify 'and content, uses the content as the body' do
+      expect(modal 'content', body: 'Your profile was updated', title: 'Profile').to include '<div class="modal-body">content</div>'
+    end
+
+    specify 'not set and with content, uses the content as the body' do
+      expect(modal 'content', title: 'Profile').to include '<div class="modal-body">content</div>'
+    end
+
+    specify 'not set and with a content, does not include a body' do
+      expect(title: 'Profile').not_to include '<div class="modal-body">'
     end
   end
 


### PR DESCRIPTION
Before this commit, the following code was valid:

``` rhtml
<%= modal 'Content only' %>
```

but resulted in an the following _ugly_ modal:

![ugly](https://cloud.githubusercontent.com/assets/7408595/4958799/806ff02a-66b2-11e4-8997-06f32cb6025b.png)

After this commit, plain-text content passed to `modal` will instead be
wrapped in a `<div class="modal-body">`, and will look like:

![nice](https://cloud.githubusercontent.com/assets/7408595/4958798/806f13ee-66b2-11e4-8b2a-a99613f93205.png)

This is exactly the same as passing the content in the `:body` option:

``` rhtml
<%= modal body: 'Content only' %>
```

In case body content and `:body` options are passed, the first takes precedence.
