### PR TITLE
Pass `progress_bar` extra params to the bar <div>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about changelogs, check
 
 ## 1.1.2 - unreleased
 
+* [ENHANCEMENT] Allow `progress_bar` to pass extra parameters to the wrapping <div>
 * [ENHANCEMENT] Wrap plain content passed to `modal` inside the modal body
 * [ENHANCEMENT] Allow `panel` to pass extra parameters to the wrapping <div>
 * [ENHANCEMENT] Wrap plain content passed to `panel` inside the panel body

--- a/examples/middleman/source/index.html.erb
+++ b/examples/middleman/source/index.html.erb
@@ -80,6 +80,7 @@
       <h1>Progress bars</h1>
 
       <%= progress_bar percentage: 30 %>
+      <%= progress_bar percentage: 30, label: 'Extra params', class: :important, id: 'my-bar', data: {value: 1} %>
       <%= progress_bar percentage: 30, label: true %>
       <%= progress_bar percentage: 30, label: "thirty percent" %>
       <%= progress_bar percentage: 30, context: :warning %>

--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -256,6 +256,7 @@
       <h1>Progress bars</h1>
 
       <%= progress_bar percentage: 30 %>
+      <%= progress_bar percentage: 30, label: 'Extra params', class: :important, id: 'my-bar', data: {value: 1} %>
 
       <%= progress_bar percentage: 30, label: true %>
       <%= progress_bar percentage: 30, label: "thirty percent" %>

--- a/lib/bh/classes/progress_bar.rb
+++ b/lib/bh/classes/progress_bar.rb
@@ -1,0 +1,84 @@
+require 'bh/classes/base'
+
+module Bh
+  module Classes
+    class ProgressBar < Base
+      # @return [#to_s] the context-related class to assign to the progress bar.
+      def context_class
+        contexts[@options[:context]]
+      end
+
+      # @return [#to_s] the class to assign to make the progress bar striped.
+      def striped_class
+        stripes[@options[:striped]]
+      end
+
+      # @return [#to_s] the class to assign to make the progress bar aniamted.
+      def animated_class
+        animations[@options[:animated]]
+      end
+
+      # @return [#to_s] the text to display as the label of the progress bar.
+      def label
+        labels[@options.fetch :label, false] || @options[:label]
+      end
+
+      def values
+        {}.tap do |values|
+          values[:style] = "width: #{percentage}%"
+          values[:role] = :progressbar
+          values[:'aria-valuenow'] = percentage
+          values[:'aria-valuemin'] = 0
+          values[:'aria-valuemax'] = 100
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to the progress bar for each possible context.
+      def contexts
+        HashWithIndifferentAccess.new.tap do |klass|
+          klass[:danger]  = :'progress-bar-danger'
+          klass[:info]    = :'progress-bar-info'
+          klass[:success] = :'progress-bar-success'
+          klass[:warning] = :'progress-bar-warning'
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to the progress bar to make it look striped.
+      def stripes
+        HashWithIndifferentAccess.new.tap do |klass|
+          klass[true]  = :'progress-bar-striped'
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to the progress bar to make it look animated.
+      def animations
+        HashWithIndifferentAccess.new.tap do |klass|
+          klass[true]  = :'progress-bar-striped active'
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the texts to uses as labels.
+      def labels
+        HashWithIndifferentAccess.new.tap do |label|
+          label[true]  = text
+          label[false]  = @app.content_tag(:span, text, class: 'sr-only')
+        end
+      end
+
+    private
+
+      def percentage
+        @options.fetch :percentage, 0
+      end
+
+      def text
+        "#{percentage}%".tap do |text|
+          text << " (#{@options[:context]})" if @options[:context]
+        end
+      end
+    end
+  end
+end

--- a/lib/bh/helpers/base_helper.rb
+++ b/lib/bh/helpers/base_helper.rb
@@ -21,15 +21,5 @@ module Bh
       block_given? ? args[1] = html_options : args[2] = html_options
       args
     end
-
-    def context_for(context = nil, options = {})
-      context = context.to_s
-
-      if options.fetch(:valid, []).map(&:to_s).include? context
-        context
-      else
-        options.fetch :default, 'default'
-      end
-    end
   end
 end

--- a/lib/bh/helpers/progress_bar_helper.rb
+++ b/lib/bh/helpers/progress_bar_helper.rb
@@ -1,66 +1,46 @@
-require 'bh/helpers/base_helper'
+require 'bh/classes/progress_bar'
 
 module Bh
-  # Provides methods to include progress bars.
-  # @see http://getbootstrap.com/components/#progress
+  # Provides the `progress_bar` helper.
   module ProgressBarHelper
-    include BaseHelper
+    # @see http://getbootstrap.com/components/#progress
+    # @return [String] an HTML block to display a progress bar.
+    # @example A 50%-filled, striped progress bar.
+    #   progress_bar percentage: 50, striped: true
+    # @overload progress_bar(options = {})
+    #   @param [Hash] options the options for the progress bar.
+    #   @option options [Boolean, #to_s] :label (false) the label to display
+    #     on top of the progress bar. If set to false, the label is hidden. If
+    #     set to true, the label is generated from the percentage value. Any
+    #     other provided value is used directly as the label.
+    #   @option options [Boolean] :striped (false) whether to display a striped
+    #     version of the progress bar (rather than solid color).
+    #   @option options [Boolean] :animated (false) whether to display an
+    #     animated version of the progress bar (rather than solid color).
+    #   @option options [#to_s] :context (:default) the contextual alternative
+    #     to apply to the progress bar. Can be `:success`, `:info`, `:warning`
+    #     or `:danger`.
+    # @overload progress_bar(array_of_options = [])
+    #   @param [Array<Hash>] array_of_options the set of options for each
+    #     progress bar. When an array is provided, a group of stacked progress
+    #     bar is displayed, each one with the corresponding options.
+    def progress_bar(args = nil)
+      progress_bars = Array.wrap(args).map do |options|
+        progress_bar = Bh::ProgressBar.new self, nil, options
+        progress_bar.extract! :percentage, :context, :striped, :animated, :label
 
-    # Returns an HTML block tag that follows the Bootstrap documentation
-    # on how to display *progress bars*.
-    # @param [Hash, Array<Hash>] options the display options for the progress
-    #   bar(s). When options is an Array, a group of stacked progress bars
-    #   is displayed, with the options specified in each item of the array.
-    # @option options [Boolean, #to_s] :label (false) the label to display
-    #   on top of the progress bar. If set to false, the label is hidden. If
-    #   set to true, the label is generated from the percentage value. Any
-    #   other provided value is used directly as the label.
-    # @option options [Boolean] :striped (false) whether to display a striped
-    #   version of the progress bar (rather than solid color).
-    # @option options [Boolean] :animated (false) whether to display an
-    #   animated version of the progress bar (rather than solid color).
-    # @option options [#to_s] :context (:default) the contextual alternative to
-    #   apply to the progress bar depending on its importance. Can be
-    #   `:success`, `:info`, `:warning` or `:danger`.
-    def progress_bar(options = {})
-      content_tag :div, class: :progress do
-        safe_join Array.wrap(options).map{|bar| progress_bar_string bar}, "\n"
-      end
-    end
-
-  private
-
-    def progress_bar_string(options = {})
-      percentage = options.fetch :percentage, 0
-
-      attributes = {}.tap do |attrs|
-        attrs[:class] = progress_bar_class(options)
-        attrs[:role] = 'progressbar'
-        attrs[:style] = "width: #{percentage}%"
-        attrs['aria-valuenow'] = percentage
-        attrs['aria-valuemin'] = 0
-        attrs['aria-valuemax'] = 100
+        progress_bar.append_class! :'progress-bar'
+        progress_bar.append_class! progress_bar.context_class
+        progress_bar.append_class! progress_bar.striped_class
+        progress_bar.append_class! progress_bar.animated_class
+        progress_bar.merge! progress_bar.values
+        progress_bar.prepend_html! progress_bar.label
+        progress_bar.render_tag :div
       end
 
-      content_tag :div, progress_bar_label(percentage, options), attributes
-    end
-
-    def progress_bar_label(percentage, options = {})
-      text = "#{percentage}%#{" (#{options[:context]})" if options[:context]}"
-      case options.fetch(:label, false)
-        when true then text
-        when false then content_tag(:span, text, class: 'sr-only')
-        else options[:label]
-      end
-    end
-
-    def progress_bar_class(options = {})
-      valid_contexts = %w(success info warning danger)
-      context = context_for options[:context], valid: valid_contexts
-      context = context.in?(valid_contexts) ? "progress-bar-#{context}" : nil
-      striped = 'progress-bar-striped' if options[:striped]
-      animated = 'progress-bar-striped active' if options[:animated]
-      ['progress-bar', context, striped, animated].compact.join ' '
+      container = Bh::Base.new(self) {safe_join progress_bars, "\n"}
+      container.append_class! :progress
+      container.render_tag :div
     end
   end
 end

--- a/spec/helpers/progress_bar_helper_spec.rb
+++ b/spec/helpers/progress_bar_helper_spec.rb
@@ -6,6 +6,8 @@ require 'bh/helpers/progress_bar_helper'
 include Bh::ProgressBarHelper
 
 describe 'progress_bar' do
+  attr_accessor :output_buffer
+
   context 'without options' do
     let(:html) { progress_bar }
 
@@ -98,6 +100,13 @@ describe 'progress_bar' do
       context 'is set to true, shows an animated color bar' do
         let(:options) { {animated: true} }
         it { expect(html).to include 'class="progress-bar progress-bar-striped active"' }
+      end
+    end
+
+    describe 'given extra options' do
+      let(:options) { {class: :important, id: 'my-bar', data: {value: 1}} }
+      specify 'passes the options to the progress bar <div>' do
+        expect(html).to include 'class="important progress-bar" data-value="1" id="my-bar"'
       end
     end
   end


### PR DESCRIPTION
Before this commit, the `progress_bar` helper ignored unknown options.
For instance the code:

``` rhtml
<%= progress_bar percentage: 30, label: 'Extra params', class: :important, id: 'my-bar', data: {value: 1} %>
```

would simply generate the following HTML

``` html
<div class="progress">
  <div class="progress-bar" role="progressbar" style="width: 30%" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
    Extra params
  </div>
</div>
```

ignoring the `:class`, `:data` and `:id` parameter.
After this commit, the result is:

``` html
<div class="progress">
  <div class="important progress-bar" id="my-bar" data-value="1" style="width: 30%" role="progressbar" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
    Extra params
  </div>
</div>
```

which should partially mitigate #39.

---

This commit also reduces public API methods from ProgressBarHelper

Before this PR, including `bh` in an app would include more methods
than necessary for progress bars: methods like `progress_bar_string` or
`context_for` that should only be accessed privately.

This PR extracts those private methods into a new Button class
that includes all the business logic to render elements and edit
attributes (e.g., attach classes), leaving the helper cleaner.
