### PR TITLE
Pass `progress_bar` extra params to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ For more information about changelogs, check
 
 ## 1.1.2 - unreleased
 
-* [ENHANCEMENT] Allow `progress_bar` to pass extra parameters to the wrapping <div>
+* [ENHANCEMENT] Allow `progress_bar` to pass extra parameters to the wrapping container
+* [ENHANCEMENT] Allow `progress_bar` to pass extra parameters to each bar
 * [ENHANCEMENT] Wrap plain content passed to `modal` inside the modal body
 * [ENHANCEMENT] Allow `panel` to pass extra parameters to the wrapping <div>
 * [ENHANCEMENT] Wrap plain content passed to `panel` inside the panel body

--- a/examples/middleman/source/index.html.erb
+++ b/examples/middleman/source/index.html.erb
@@ -80,7 +80,8 @@
       <h1>Progress bars</h1>
 
       <%= progress_bar percentage: 30 %>
-      <%= progress_bar percentage: 30, label: 'Extra params', class: :important, id: 'my-bar', data: {value: 1} %>
+      <%= progress_bar percentage: 30, label: 'With bar params', class: :important, id: 'my-bar', data: {value: 1} %>
+      <%= progress_bar({percentage: 30, label: 'With container params'}, class: :important, id: 'my-container') %>
       <%= progress_bar percentage: 30, label: true %>
       <%= progress_bar percentage: 30, label: "thirty percent" %>
       <%= progress_bar percentage: 30, context: :warning %>

--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -256,7 +256,8 @@
       <h1>Progress bars</h1>
 
       <%= progress_bar percentage: 30 %>
-      <%= progress_bar percentage: 30, label: 'Extra params', class: :important, id: 'my-bar', data: {value: 1} %>
+      <%= progress_bar percentage: 30, label: 'With bar params', class: :important, id: 'my-bar', data: {value: 1} %>
+      <%= progress_bar({percentage: 30, label: 'With container params'}, class: :important, id: 'my-container') %>
 
       <%= progress_bar percentage: 30, label: true %>
       <%= progress_bar percentage: 30, label: "thirty percent" %>

--- a/lib/bh/helpers/progress_bar_helper.rb
+++ b/lib/bh/helpers/progress_bar_helper.rb
@@ -24,7 +24,7 @@ module Bh
     #   @param [Array<Hash>] array_of_options the set of options for each
     #     progress bar. When an array is provided, a group of stacked progress
     #     bar is displayed, each one with the corresponding options.
-    def progress_bar(args = nil)
+    def progress_bar(args = nil, options = {})
       progress_bars = Array.wrap(args).map do |options|
         progress_bar = Bh::ProgressBar.new self, nil, options
         progress_bar.extract! :percentage, :context, :striped, :animated, :label
@@ -38,7 +38,7 @@ module Bh
         progress_bar.render_tag :div
       end
 
-      container = Bh::Base.new(self) {safe_join progress_bars, "\n"}
+      container = Bh::Base.new(self, options) {safe_join progress_bars, "\n"}
       container.append_class! :progress
       container.render_tag :div
     end

--- a/spec/helpers/progress_bar_helper_spec.rb
+++ b/spec/helpers/progress_bar_helper_spec.rb
@@ -120,4 +120,12 @@ describe 'progress_bar' do
       expect(html).to match %r{^<div class="progress"><div.+aria-valuenow="20" class="progress-bar progress-bar-success".+style="width: 20%">20% \(success\)</div>\n<div.+aria-valuenow="30" class="progress-bar progress-bar-striped active".+style="width: 30%">Current</div></div>$}m
     end
   end
+
+  context 'with progress bar options and extra options' do
+    let(:html) { progress_bar({percentage: 30}, class: :important, id: 'my-container') }
+
+    it 'passes the extra options to the wrapping container' do
+      expect(html).to match '<div class="important progress" id="my-container"><div.+</div></div>'
+    end
+  end
 end


### PR DESCRIPTION
Before this commit, the `progress_bar` helper did not accept options
for the outer container. For instance the code:

``` rhtml
<%= progress_bar({percentage: 30, label: 'With container params'}, class: :important, id: 'my-container') %>
```

would fail. After this commit, the result is:

``` html
<div class="important progress" id="my-container">
  <div class="progress-bar" style="width: 30%" role="progressbar" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
    With container params
  </div>
</div>
```

which should partially mitigate #39.

Note that the parentheses and brackets are required to distinguish between
parameters passed to the bar and to the wrapping container.
