### PR TITLE
Pass `nav` extra params to the <nav>

### DIFF
--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -94,6 +94,12 @@
 
       <h1>Navs</h1>
 
+      <%= nav class: :important, id: 'my-nav', data: {value: 1} do %>
+        <%= link_to 'Home', '/' %>
+        <%= link_to 'Users', '/users' %>
+        <%= link_to 'Profile', '/profile' %>
+      <% end %>
+
       <%= nav do %>
         <%= link_to 'Home', '/' %>
         <%= link_to 'Users', '/users' %>

--- a/lib/bh/classes/nav.rb
+++ b/lib/bh/classes/nav.rb
@@ -1,0 +1,34 @@
+require 'bh/classes/base'
+
+module Bh
+  module Classes
+    class Nav < Base
+      # @return [#to_s] the style-related class to assign to the nav.
+      def style_class
+        styles[@options[:as]]
+      end
+
+      # @return [#to_s] the layout-related class to assign to the nav.
+      def layout_class
+        layouts[@options[:layout]]
+      end
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to navs for each possible style.
+      def styles
+        HashWithIndifferentAccess.new(:'nav-tabs').tap do |klass|
+          klass[:pills] = :'nav-pills'
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to buttons for each possible layout.
+      def layouts
+        HashWithIndifferentAccess.new.tap do |klass|
+          klass[:justified] = :'nav-justified'
+          klass[:stacked]   = :'nav-stacked'
+        end
+      end
+    end
+  end
+end

--- a/lib/bh/core_ext/rails/link_to_helper.rb
+++ b/lib/bh/core_ext/rails/link_to_helper.rb
@@ -21,7 +21,7 @@ module Bh
         content_tag :li, role: :presentation do
           super *add_menu_item_attributes!(*args, &block), &block
         end
-      elsif @nav_link
+      elsif Bh::Stack.find Bh::Nav
         content_tag :li, super(*args, &block), nav_item_options(*args, &block)
       else
         super *args, &block

--- a/lib/bh/helpers/nav_helper.rb
+++ b/lib/bh/helpers/nav_helper.rb
@@ -1,51 +1,34 @@
-require 'bh/helpers/base_helper'
+require 'bh/classes/nav'
 
 module Bh
-  # Provides methods to include navs.
-  # @see http://getbootstrap.com/components/#nav
+  # Provides the `nav` helper.
   module NavHelper
-    include BaseHelper
-
-    # Returns an HTML block tag that follows the Bootstrap documentation
-    # on how to display *navs*.
-    #
-    # The skeleton of the nav is an unordered list; its content is passed as a
-    # block as a list of navigation items.
-    # Since the most common use for a nav is to display a menu of links, a
-    # variable is set inside the block so that every call to +link_to+
-    # generates a link *surrounded by a list item*.
-    # @example An justified nav with two links.
-    #   nav layout: :justified do
-    #     link_to 'Home', '/'
-    #     link_to 'Profile', '/profile'
-    #   end
-    #
-    # @return [String] an HTML block tag for a nav.
-    # @param [Hash] options the display options for the nav.
-    # @option options [#to_s] :as ('tabs') the style to use for the nav.
-    #   Valid values are: :tabs and :pills.
-    # @option options [#to_s] :layout (nil) if set, the layout of the nav.
-    #   Valid values are: :justified and :stacked.
-    # @yield block the content of the nav
     # @see http://getbootstrap.com/components/#nav
+    # @return [String] an HTML block to display a nav.
+    # @example A pills-styled nav with a link.
+    #   nav as: :pills do
+    #     link_to 'Home', '/'
+    #   end
+    # @param [Hash] options the display options for the nav.
+    # @option options [#to_s] :as (:tabs) the style of the nav. Can be `:tabs`
+    #   or `:pills`.
+    # @option options [#to_s] :layout the layout of the nav. Can be
+    #   `:justified` or `:stacked`.
+    # @yieldreturn [#to_s] the content of the nav.
     def nav(options = {}, &block)
-      @nav_link = true
-      nav = content_tag :ul, nav_options(options), &block
-      nav.tap{ @nav_link = false }
-    end
+      nav = Bh::Nav.new(self, options, &block)
+      nav.extract! :as, :layout
 
-  private
-
-    def nav_options(options = {})
-      append_class! options, 'nav'
+      nav.append_class! :nav
       if @navbar_id
-        append_class! options, 'navbar-nav'
+        nav.append_class! :'navbar-nav'
       else
-        options[:role] = 'tablist'
-        append_class! options, "nav-#{options.fetch :as, 'tabs'}"
-        append_class! options, "nav-#{options[:layout]}" if options[:layout]
+        nav.merge! role: :tablist
+        nav.append_class! nav.style_class
+        nav.append_class! nav.layout_class
       end
-      options.slice :role, :class
+
+      nav.render_tag :ul
     end
   end
 end

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -44,6 +44,13 @@ describe 'nav' do
     end
   end
 
+  describe 'with extra options' do
+    let(:options) { {class: :important, id: 'my-nav', data: {value: 1}} }
+    specify 'passes the option to the <nav>' do
+      expect(html).to include 'ul class="important nav nav-tabs" data-value="1" id="my-nav"'
+    end
+  end
+
   describe 'within a navbar' do
     let(:html) { navbar { nav options, &block } }
     specify 'applies roles and classes specific to navbar' do


### PR DESCRIPTION
Before this commit, the `nav` helper ignored unknown options.
For instance the code:

``` rhtml
<%= nav class: :important, id: 'my-nav', data: {value: 1} do %>
  <%= link_to 'Home', '/' %>
<% end %>
```

would simply generate the following HTML

``` html
<ul role="tablist" class="important nav nav-tabs">
  <li class="active"><a href="/">Home</a></li>
</ul>
```

ignoring the `:data` and `:id` parameter.
After this commit, the result is:

``` html
<ul class="important nav nav-tabs" id="my-nav" data-value="1" role="tablist">
  <li class="active"><a href="/">Home</a></li>
</ul>
```

which should partially mitigate #39.

---

This commit also reduces public API methods from NavHelper

Before this PR, including `bh` in an app would include more methods
than necessary for navs: methods like `nav_options that should only be
accessed privately.

This PR extracts those private methods into a new Nav class
that includes all the business logic to render elements and edit
attributes (e.g., attach classes), leaving the helper cleaner.
