### PR TITLE
Reduce public API methods from NavbarHelper

### DIFF
--- a/lib/bh/classes/navbar.rb
+++ b/lib/bh/classes/navbar.rb
@@ -1,0 +1,78 @@
+require 'bh/classes/base'
+
+module Bh
+  module Classes
+    class Navbar < Base
+      # @return [#to_s] the style-related class to assign to the navbar.
+      def style_class
+        styles[@options[:inverted]]
+      end
+
+      # @return [#to_s] the position-related class to assign to the navbar.
+      def position_class
+        positions[@options[:position]]
+      end
+
+      # @return [#to_s] the layout-related class to assign to the navbar.
+      def layout_class
+        layouts[@options[:fluid]]
+      end
+
+      def id
+        @id ||= "navbar-collapse-#{rand 10**10}"
+      end
+
+      # @private
+      # The fixed navbar will overlay your other content, unless you add padding
+      # to the top or bottom of the <body>. Try out your own values or use our
+      # snippet below. Tip: By default, the navbar is 50px high.
+      # @see http://getbootstrap.com/components/#navbar-fixed-top
+      def body_padding_style
+        if body_padding_amount && body_padding_type
+          style = "padding-#{body_padding_type}: #{body_padding_amount}px"
+          @app.content_tag :style, "body {#{style}}"
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to navbars to specify a color combination.
+      def styles
+        HashWithIndifferentAccess.new(:'navbar-default').tap do |klass|
+          klass[true] = :'navbar-inverse'
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to navbars to set a specific DOM position.
+      def positions
+        HashWithIndifferentAccess.new.tap do |klass|
+          klass[:static]        = :'navbar-static-top'
+          klass[:static_top]    = :'navbar-static-top'
+          klass[:top]           = :'navbar-fixed-top'
+          klass[:fixed_top]     = :'navbar-fixed-top'
+          klass[:bottom]        = :'navbar-fixed-bottom'
+          klass[:fixed_bottom]  = :'navbar-fixed-bottom'
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
+      #   append to the navbar container for each possible layout.
+      def layouts
+        HashWithIndifferentAccess.new(:'container').tap do |klass|
+          klass[true] = :'container-fluid'
+        end
+      end
+
+    private
+
+      def body_padding_amount
+        @options.fetch :padding, 70
+      end
+
+      def body_padding_type
+        /navbar-fixed-(?<type>top|bottom)$/ =~ position_class
+        type
+      end
+    end
+  end
+end

--- a/lib/bh/core_ext/rails/button_to_helper.rb
+++ b/lib/bh/core_ext/rails/button_to_helper.rb
@@ -1,4 +1,6 @@
 require 'bh/helpers/base_helper'
+require 'bh/classes/navbar'
+require 'bh/classes/stack'
 
 module Bh
   module ButtonToHelper
@@ -10,7 +12,7 @@ module Bh
     # @see http://getbootstrap.com/components/#navbar-buttons
     def button_to(*args, &block)
       args = append_class_as! :class, 'btn', *args, &block
-      if @navbar_id
+      if Bh::Stack.find(Bh::Navbar)
         args = append_class_as! :form_class, 'navbar-form', *args, &block
       end
       super *args, &block

--- a/lib/bh/helpers/horizontal_helper.rb
+++ b/lib/bh/helpers/horizontal_helper.rb
@@ -1,14 +1,16 @@
-require 'bh/classes/base'
+require 'bh/classes/navbar'
 
 module Bh
   # Provides the `horizontal` helper.
   module HorizontalHelper
 
     def horizontal(*args, &block)
-      horizontal = Bh::Base.new self, *args, &block
-      horizontal.append_class! :'collapse navbar-collapse'
-      horizontal.merge! id: navbar_id
-      horizontal.render_tag :div
+      if navbar = Bh::Stack.find(Bh::Navbar) || OpenStruct.new(id: 'navbar-id')
+        horizontal = Bh::Base.new self, *args, &block
+        horizontal.append_class! :'collapse navbar-collapse'
+        horizontal.merge! id: navbar.id
+        horizontal.render_tag :div
+      end
     end
   end
 end

--- a/lib/bh/helpers/nav_helper.rb
+++ b/lib/bh/helpers/nav_helper.rb
@@ -1,4 +1,5 @@
 require 'bh/classes/nav'
+require 'bh/classes/navbar'
 
 module Bh
   # Provides the `nav` helper.
@@ -20,7 +21,7 @@ module Bh
       nav.extract! :as, :layout
 
       nav.append_class! :nav
-      if @navbar_id
+      if Bh::Stack.find(Bh::Navbar)
         nav.append_class! :'navbar-nav'
       else
         nav.merge! role: :tablist

--- a/lib/bh/helpers/navbar_helper.rb
+++ b/lib/bh/helpers/navbar_helper.rb
@@ -36,60 +36,16 @@ module Bh
     #   navbar from overlaying the content.
     # @yieldreturn [#to_s] the content of the navbar.
     def navbar(options = {}, &block)
-      @navbar_id = rand 10**7
-      nav_tag = navbar_string options, &block
-      navbar = safe_join [navbar_style_tag(options), nav_tag].compact, "\n"
-      navbar.tap{ @navbar_id = nil }
-    end
+      navbar = Bh::Navbar.new(self, options, &block)
+      navbar.extract! :inverted, :position, :padding, :fluid
 
-  private
+      navbar.append_class_to! :navigation, :navbar
+      navbar.append_class_to! :navigation, navbar.style_class
+      navbar.append_class_to! :navigation, navbar.position_class
+      navbar.append_class_to! :div, navbar.layout_class
+      navbar.prepend_html! navbar.body_padding_style
 
-    def navbar_string(options = {}, &block)
-      content_tag :nav, role: 'navigation', class: navbar_class(options) do
-        content_tag :div, class: navbar_container_class(options), &block
-      end
-    end
-
-    def navbar_id
-      "navbar-collapse-#{@navbar_id}"
-    end
-
-    # @private
-    # The fixed navbar will overlay your other content, unless you add padding
-    # to the top or bottom of the <body>. Try out your own values or use our
-    # snippet below. Tip: By default, the navbar is 50px high.
-    # @see http://getbootstrap.com/components/#navbar-fixed-top
-    def navbar_style_tag(options = {})
-      padding_value = options.fetch :padding, 70
-      if padding_value && padding_type = padding_type_for(options[:position])
-        content_tag :style, "body {padding-#{padding_type}: #{padding_value}px}"
-      end
-    end
-
-    def padding_type_for(position)
-      /fixed-(?<type>top|bottom)$/ =~ navbar_position_class_for(position)
-      type
-    end
-
-    def navbar_class(options = {})
-      style = options[:inverted] ? 'inverse' : 'default'
-      position = navbar_position_class_for options[:position]
-      append_class! options, 'navbar'
-      append_class! options, "navbar-#{style}"
-      append_class! options, "navbar-#{position}" if position
-      options[:class]
-    end
-
-    def navbar_position_class_for(position)
-      case position.to_s
-        when 'static', 'static_top' then 'static-top'
-        when 'top', 'fixed_top' then 'fixed-top'
-        when 'bottom', 'fixed_bottom' then 'fixed-bottom'
-      end
-    end
-
-    def navbar_container_class(options = {})
-      options[:fluid] ? 'container-fluid' : 'container'
+      navbar.render_partial 'navbar'
     end
   end
 end

--- a/lib/bh/helpers/vertical_helper.rb
+++ b/lib/bh/helpers/vertical_helper.rb
@@ -1,3 +1,4 @@
+require 'bh/classes/navbar'
 require 'bh/classes/vertical'
 
 module Bh
@@ -5,10 +6,12 @@ module Bh
   module VerticalHelper
 
     def vertical(*args, &block)
-      vertical = Bh::Vertical.new self, *args, &block
-      vertical.append_class! :'navbar-header'
-      vertical.prepend_html! vertical.toggle_button(navbar_id)
-      vertical.render_tag :div
+      if navbar = Bh::Stack.find(Bh::Navbar) || OpenStruct.new(id: 'navbar-id')
+        vertical = Bh::Vertical.new self, *args, &block
+        vertical.append_class! :'navbar-header'
+        vertical.prepend_html! vertical.toggle_button(navbar.id)
+        vertical.render_tag :div
+      end
     end
   end
 end

--- a/lib/bh/views/bh/_navbar.html.erb
+++ b/lib/bh/views/bh/_navbar.html.erb
@@ -1,0 +1,5 @@
+<nav class="<%= navigation[:class] %>" role="navigation">
+  <div class="<%= div[:class] %>">
+    <%= content %>
+  </div>
+</nav>


### PR DESCRIPTION
Before this PR, including `bh` in an app would include more methods
than necessary for navbar: methods like `navbar_id` and
`navbar_string` that should only be accessed privately.

This PR extracts those private methods into a new Navbar class
that includes all the business logic to render elements and edit
attributes (e.g., attach classes), leaving the helper cleaner.
