### PR TITLE
Only allow `vertical` and `horizontal` in `navbar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about changelogs, check
 
 ## 1.1.2 - unreleased
 
+* [ENHANCEMENT] Don’t render anything when `vertical` and `horizontal` are not wrapped in a `navbar`
 * [ENHANCEMENT] Allow `progress_bar` to pass extra parameters to the wrapping container
 * [ENHANCEMENT] Allow `progress_bar` to pass extra parameters to each bar
 * [ENHANCEMENT] Wrap plain content passed to `modal` inside the modal body

--- a/lib/bh/helpers/horizontal_helper.rb
+++ b/lib/bh/helpers/horizontal_helper.rb
@@ -5,7 +5,7 @@ module Bh
   module HorizontalHelper
 
     def horizontal(*args, &block)
-      if navbar = Bh::Stack.find(Bh::Navbar) || OpenStruct.new(id: 'navbar-id')
+      if navbar = Bh::Stack.find(Bh::Navbar)
         horizontal = Bh::Base.new self, *args, &block
         horizontal.append_class! :'collapse navbar-collapse'
         horizontal.merge! id: navbar.id

--- a/lib/bh/helpers/vertical_helper.rb
+++ b/lib/bh/helpers/vertical_helper.rb
@@ -6,7 +6,7 @@ module Bh
   module VerticalHelper
 
     def vertical(*args, &block)
-      if navbar = Bh::Stack.find(Bh::Navbar) || OpenStruct.new(id: 'navbar-id')
+      if navbar = Bh::Stack.find(Bh::Navbar)
         vertical = Bh::Vertical.new self, *args, &block
         vertical.append_class! :'navbar-header'
         vertical.prepend_html! vertical.toggle_button(navbar.id)

--- a/spec/helpers/navbar_helper_spec.rb
+++ b/spec/helpers/navbar_helper_spec.rb
@@ -124,56 +124,74 @@ describe 'navbar' do
   end
 end
 
-describe 'vertical' do
+describe 'vertical not nested in navbar' do
+  specify 'returns nil' do
+    expect(vertical 'content').to be_nil
+    expect(vertical { 'content' }).to be_nil
+    expect(vertical 'content', class: :important).to be_nil
+    expect(vertical(class: :important) { 'content' }).to be_nil
+  end
+end
+
+describe 'vertical nested in navbar' do
   describe 'accepts as parameters:' do
     let(:behave) { be_a String }
 
     specify 'a string (content)' do
-      expect(vertical 'content').to behave
+      expect(navbar {vertical 'content'}).to behave
     end
 
     specify 'a block (content)' do
-      expect(vertical { 'content' }).to behave
+      expect(navbar {vertical { 'content' }}).to behave
     end
 
     specify 'a string (content) + a hash (options)' do
-      expect(vertical 'content', class: :important).to behave
+      expect(navbar {vertical 'content', class: :important}).to behave
     end
 
     specify 'a hash (options) + a block (content)' do
-      expect(vertical(class: :important) { 'content' }).to behave
+      expect(navbar {vertical(class: :important) { 'content' }}).to behave
     end
   end
 
   describe 'adds a toggle button and bars' do
-    let(:html) { vertical 'content' }
+    let(:html) { navbar {vertical 'content'} }
     it { expect(html).to match %r{<button class="navbar-toggle" data-target="#.+?" data-toggle="collapse" type="button"><span class="sr-only">Toggle navigation</span>\n<span class="icon-bar"></span>\n<span class="icon-bar"></span>\n<span class="icon-bar"></span></button}m }
   end
 end
 
-describe 'horizontal' do
+describe 'horizontal not nested in navbar' do
+  specify 'returns nil' do
+    expect(horizontal 'content').to be_nil
+    expect(horizontal { 'content' }).to be_nil
+    expect(horizontal 'content', class: :important).to be_nil
+    expect(horizontal(class: :important) { 'content' }).to be_nil
+  end
+end
+
+describe 'horizontal nested in navbar' do
   describe 'accepts as parameters:' do
     let(:behave) { be_a String }
 
     specify 'a string (content)' do
-      expect(horizontal 'content').to behave
+      expect(navbar {horizontal 'content'}).to behave
     end
 
     specify 'a block (content)' do
-      expect(horizontal { 'content' }).to behave
+      expect(navbar {horizontal { 'content' }}).to behave
     end
 
     specify 'a string (content) + a hash (options)' do
-      expect(horizontal 'content', class: :important).to behave
+      expect(navbar {horizontal 'content', class: :important}).to behave
     end
 
     specify 'a hash (options) + a block (content)' do
-      expect(horizontal(class: :important) { 'content' }).to behave
+      expect(navbar {horizontal(class: :important) { 'content' }}).to behave
     end
   end
 
   describe 'adds a collapsable div' do
-    let(:html) { horizontal 'content' }
+    let(:html) { navbar {horizontal 'content'} }
     it { expect(html).to match %r{<div class="collapse navbar-collapse" id=".+?">content</div>} }
   end
 end


### PR DESCRIPTION
When used outside of the `navbar` block, they will not render anything.
