### PR TITLE
Ability to add as: :button to link_to

### DIFF
--- a/lib/bh/core_ext/rails/link_to_helper.rb
+++ b/lib/bh/core_ext/rails/link_to_helper.rb
@@ -17,6 +17,18 @@ module Bh
     # Overrides ActionView +link_to+ to be able to add the 'navbar-brand'
     # class to the link in case the link is inside of an alert.
     def link_to(*args, &block)
+      options = (block_given? ? args[1] : args[2]) || {}
+      case options.delete(:as).to_s
+      when 'btn', 'button'
+        button = Bh::Button.new(self, *args, &block)
+        button.extract! :context, :size, :layout
+        button_class  = [:btn] 
+        button_class << button.context_class
+        button_class << button.size_class
+        button_class << button.layout_class
+        add_link_class!(button_class.join(' '), *args, &block)
+      end
+
       if Bh::Stack.find Bh::AlertBox
         super *add_link_class!('alert-link', *args, &block), &block
       elsif Bh::Stack.find Bh::Vertical

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -70,6 +70,52 @@ describe 'link_to' do
     end
   end
 
+  context 'link as button' do
+    specify 'by default, does not add button classes to link' do
+      expect(link_to 'Home', url).not_to include 'btn'
+    end
+
+    specify 'given as button option, adds default button classes' do
+      expect(link_to 'Home', url, as: :button).to include 'btn btn-default'
+    end
+
+    specify 'given btn size, adds size class link' do
+      expect(link_to 'Home', url, as: :button, size: :lg).to include 'btn-lg'
+    end
+
+    specify 'given btn context, adds context class link' do
+      expect(link_to 'Home', url, as: :button, context: :danger).to include 'btn btn-danger'
+    end
+
+    context 'inside an alert' do
+      specify 'applies the "btn" class' do
+        expect(alert_box { link_to(url, as: :btn) { 'Home' } }).to include 'btn'
+      end
+    end
+
+    context 'inside a nav' do
+      specify 'applies the "btn" class' do
+        expect(nav { link_to(url, as: :btn) { 'Home' } }).to include 'btn'
+      end
+    end
+
+    context 'used with a block' do
+      specify 'given as button option and content as block, adds default button classes' do
+        link = link_to url, as: :button do
+          'Home'
+        end
+        expect(link).to include 'btn btn-default'
+      end
+
+      specify 'given btn context, adds context class link' do
+        link = link_to url, as: :button, context: :danger do
+          'Home'
+        end
+        expect(link).to include 'btn btn-danger'
+      end
+    end
+  end
+
   context 'used with a block' do
     let(:link) { link_to(url) { 'Home' } }
 


### PR DESCRIPTION
Added as: :button option to link_to helper.

Example usage:

``` ruby
link_to 'Home', url, as: :btn, size: :lg, context: :info

link_to url, as: :button, size: :lg, context: :info do
  'Home'
end
```
