### PR TITLE
Pass `id` param to navbar subcomponents

### DIFF
--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -133,7 +133,7 @@
 
       <h1>Navbars</h1>
 
-      <%= navbar do %>
+      <%= navbar id: 'my-navbar' do %>
         <%= vertical do %>
           <%= link_to 'Home', root_path %>
         <% end %>

--- a/lib/bh/classes/navbar.rb
+++ b/lib/bh/classes/navbar.rb
@@ -19,7 +19,7 @@ module Bh
       end
 
       def id
-        @id ||= "navbar-collapse-#{rand 10**10}"
+        @id ||= @options.fetch :id, "navbar-collapse-#{rand 10**10}"
       end
 
       # @private

--- a/lib/bh/helpers/navbar_helper.rb
+++ b/lib/bh/helpers/navbar_helper.rb
@@ -37,7 +37,7 @@ module Bh
     # @yieldreturn [#to_s] the content of the navbar.
     def navbar(options = {}, &block)
       navbar = Bh::Navbar.new(self, options, &block)
-      navbar.extract! :inverted, :position, :padding, :fluid
+      navbar.extract! :inverted, :position, :padding, :fluid, :id
 
       navbar.append_class_to! :navigation, :navbar
       navbar.append_class_to! :navigation, navbar.style_class

--- a/spec/helpers/navbar_helper_spec.rb
+++ b/spec/helpers/navbar_helper_spec.rb
@@ -158,6 +158,13 @@ describe 'vertical nested in navbar' do
     let(:html) { navbar {vertical 'content'} }
     it { expect(html).to match %r{<button class="navbar-toggle" data-target="#.+?" data-toggle="collapse" type="button"><span class="sr-only">Toggle navigation</span>\n<span class="icon-bar"></span>\n<span class="icon-bar"></span>\n<span class="icon-bar"></span></button}m }
   end
+
+  describe 'with extra options' do
+    let(:options) { {class: :important, id: 'my-navbar', data: {value: 1}} }
+    it 'passes the options to the <div> element' do
+      expect(navbar {vertical 'content', options}).to include 'div class="important navbar-header" data-value="1" id="my-navbar"'
+    end
+  end
 end
 
 describe 'horizontal not nested in navbar' do
@@ -194,6 +201,13 @@ describe 'horizontal nested in navbar' do
     let(:html) { navbar {horizontal 'content'} }
     it { expect(html).to match %r{<div class="collapse navbar-collapse" id=".+?">content</div>} }
   end
+
+  describe 'with extra options' do
+    let(:options) { {class: :important, data: {value: 1}} }
+    it 'passes the options to the <div> element' do
+      expect(navbar {horizontal 'content', options}).to include 'div class="important collapse navbar-collapse" data-value="1"'
+    end
+  end
 end
 
 describe 'multiple navbars' do
@@ -210,5 +224,14 @@ describe 'multiple navbars' do
 
     expect(navbar_ids.size).to eq 2
     expect(navbar_ids.uniq.size).to eq 2
+  end
+end
+
+describe 'with the :id navbar option' do
+  let(:id) { 'my-navbar' }
+  let(:html) { navbar(id: id) {safe_join [vertical, horizontal]} }
+  it 'uses the id for the vertical and horizontal elements' do
+    expect(html).to include %Q{button class="navbar-toggle" data-target="##{id}"}
+    expect(html).to include %Q{div class="collapse navbar-collapse" id="#{id}"}
   end
 end


### PR DESCRIPTION
In a navbar, the ID of the horizontal element must match the 'data-target'
of the vertical element in order for the the navbar "toggle" to work.

Before this commit, a random ID was generated for each navbar.
After this commit, a specific ID can be assigned by passing the `:id`
parameter to the wrapping `navbar`.

Any other extra param of the `vertical` and `horizontal` helpers is passed
to their respective `<div>` elements, which should partially mitigate #39.
