### PR TITLE
Reduce public API methods from LinkToHelper

### DIFF
--- a/lib/bh/classes/link_to.rb
+++ b/lib/bh/classes/link_to.rb
@@ -1,0 +1,22 @@
+require 'bh/classes/base'
+
+module Bh
+  module Classes
+    class LinkTo < Base
+      def initialize(app = nil, *args, &block)
+        @url = extract_url_from(*args, &block)
+        super
+      end
+
+      def url
+        @url
+      end
+
+    private
+
+      def extract_url_from(*args)
+        args.delete_at(block_given? ? 0 : 1)
+      end
+    end
+  end
+end

--- a/spec/rails/link_to_helper_spec.rb
+++ b/spec/rails/link_to_helper_spec.rb
@@ -13,12 +13,14 @@ include Bh::DropdownHelper
 include Bh::NavHelper
 include Bh::NavbarHelper
 
+include ActionView::Helpers::UrlHelper # for link_to
 include Bh::Rails::Helpers
 
 describe 'link_to' do
   let(:request) { ActionDispatch::Request.new request_options }
   let(:request_options) { {'REQUEST_METHOD' => 'GET'} }
   let(:url) { '/' }
+  attr_accessor :output_buffer
 
   context 'used without a block' do
     let(:link) { link_to 'Home', url }


### PR DESCRIPTION
Before this PR, including `bh` in an app would include more methods
than necessary for link_to: methods like `add_link_class!` and
`nav_item_options` that should only be accessed privately.

This PR extracts those private methods into a new LinkTo class
that includes all the business logic to render elements and edit
attributes (e.g., attach classes), leaving the helper cleaner.
