### PR TITLE
Stop requiring ActionView in shared tests

### DIFF
--- a/lib/bh/classes/alert_box.rb
+++ b/lib/bh/classes/alert_box.rb
@@ -5,7 +5,7 @@ module Bh
     class AlertBox < Base
       # @return [#to_s] the content-related class to assign to the alert box.
       def context_class
-        contexts[@options.fetch :context, @options[:priority]]
+        AlertBox.contexts[@options.fetch :context, @options[:priority]]
       end
 
       # @return [#to_s] the HTML to show a dismissible button for the alert box.
@@ -16,9 +16,11 @@ module Bh
         end
       end
 
+    private
+
       # @return [Hash<Symbol, String>] the class that Bootstrap requires to
       #   append to an alert box based on its context.
-      def contexts
+      def self.contexts
         HashWithIndifferentAccess.new(:'alert-info').tap do |klass|
           klass[:alert]   = :'alert-danger'
           klass[:danger]  = :'alert-danger'

--- a/lib/bh/classes/button.rb
+++ b/lib/bh/classes/button.rb
@@ -5,22 +5,24 @@ module Bh
     class Button < Base
       # @return [#to_s] the context-related class to assign to the button.
       def context_class
-        contexts[@options[:context]]
+        Button.contexts[@options[:context]]
       end
 
       # @return [#to_s] the size-related class to assign to the alert box.
       def size_class
-        sizes[@options[:size]]
+        Button.sizes[@options[:size]]
       end
 
       # @return [#to_s] the layout-related class to assign to the alert box.
       def layout_class
-        layouts[@options[:layout]]
+        Button.layouts[@options[:layout]]
       end
+
+    private
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to buttons for each possible context.
-      def contexts
+      def self.contexts
         HashWithIndifferentAccess.new(:'btn-default').tap do |klass|
           klass[:danger]  = :'btn-danger'
           klass[:info]    = :'btn-info'
@@ -33,7 +35,7 @@ module Bh
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to buttons for each possible size.
-      def sizes
+      def self.sizes
         HashWithIndifferentAccess.new.tap do |klass|
           klass[:extra_small] = :'btn-xs'
           klass[:large]       = :'btn-lg'
@@ -46,7 +48,7 @@ module Bh
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to buttons for each possible layout.
-      def layouts
+      def self.layouts
         HashWithIndifferentAccess.new.tap do |klass|
           klass[:block] = :'btn-block'
         end

--- a/lib/bh/classes/dropdown.rb
+++ b/lib/bh/classes/dropdown.rb
@@ -5,17 +5,17 @@ module Bh
     class Dropdown < Button
       # @return [#to_s] the group-related class to assign to the dropdown.
       def groupable_class
-        groupables[@options[:groupable]]
+        Dropdown.groupables[@options[:groupable]]
       end
 
       # @return [#to_s] the direction-related class to assign to the dropdown.
       def direction_class
-        directions[@options[:direction]]
+        Dropdown.directions[@options[:direction]]
       end
 
       # @return [#to_s] the align-related class to assign to the dropdown.
       def align_class
-        aligns[@options[:align]]
+        Dropdown.aligns[@options[:align]]
       end
 
       def id
@@ -26,9 +26,11 @@ module Bh
         @options[:split] ? 'dropdown_split' : 'dropdown'
       end
 
+    private
+
       # @return [Hash<Symbol, String>] the class that Bootstrap requires to
       #   append to a dropdown to display it as inline or block.
-      def groupables
+      def self.groupables
         HashWithIndifferentAccess.new(:'btn-group').tap do |klass|
           klass[false] = :dropdown
         end
@@ -36,7 +38,7 @@ module Bh
 
       # @return [Hash<Symbol, String>] the class that Bootstrap requires to
       #   append to a dropdown to show a drop-"up" or -"down".
-      def directions
+      def self.directions
         HashWithIndifferentAccess.new.tap do |klass|
           klass[:up] = :dropup
         end
@@ -44,7 +46,7 @@ module Bh
 
       # @return [Hash<Symbol, String>] the class that Bootstrap requires to
       #   append to a dropdown to left- or right- align to the toggle button.
-      def aligns
+      def self.aligns
         HashWithIndifferentAccess.new.tap do |klass|
           klass[:right] = :'dropdown-menu-right'
         end

--- a/lib/bh/classes/icon.rb
+++ b/lib/bh/classes/icon.rb
@@ -6,7 +6,7 @@ module Bh
       # @return [#to_s] the class to assign to the icon based on the Vector
       #   Icon library used.
       def library_class
-        libraries[@options[:library].to_s.underscore] || @options[:library]
+        Icon.libraries[@options[:library].to_s.underscore] || @options[:library]
       end
 
       # @return [#to_s] the class to assign to the icon based on the name
@@ -17,10 +17,11 @@ module Bh
         end
       end
 
+    private
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to icons for each possible vector icon library.
-      def libraries
+      def self.libraries
         HashWithIndifferentAccess.new(nil).tap do |klass|
           klass[:font_awesome]  = :'fa'
           klass[:glyphicons]    = :'glyphicon'

--- a/lib/bh/classes/modal.rb
+++ b/lib/bh/classes/modal.rb
@@ -1,9 +1,8 @@
-
 require 'bh/classes/button'
 
 module Bh
   module Classes
-    class Modal < Button
+    class Modal < Base
       # Differently from other classes, Modal works with no content or block,
       # given that the options[:body] is passed, in which case it functions
       # as the content.
@@ -17,17 +16,17 @@ module Bh
 
       # @return [#to_s] the context-related class to assign to the modal button.
       def button_context_class
-        contexts[@options.fetch(:button, {})[:context]]
+        Button.contexts[@options.fetch(:button, {})[:context]]
       end
 
       # @return [#to_s] the size-related class to assign to the modal button.
       def button_size_class
-        sizes[@options.fetch(:button, {})[:size]]
+        Button.sizes[@options.fetch(:button, {})[:size]]
       end
 
       # @return [#to_s] the size-related class to assign to the modal dialog.
       def dialog_size_class
-        dialog_sizes[@options[:size]]
+        Modal.dialog_sizes[@options[:size]]
       end
 
       # @return [#to_s] the caption for the modal button.
@@ -44,9 +43,11 @@ module Bh
         @options.fetch :id, "modal-#{rand 10**10}"
       end
 
+    private
+
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to the modal dialog for each possible size.
-      def dialog_sizes
+      def self.dialog_sizes
         HashWithIndifferentAccess.new.tap do |klass|
           klass[:large]       = :'modal-lg'
           klass[:lg]          = :'modal-lg'
@@ -54,8 +55,6 @@ module Bh
           klass[:small]       = :'modal-sm'
         end
       end
-
-    private
 
       def extract_content_from(*args, &block)
         if block_given?

--- a/lib/bh/classes/nav.rb
+++ b/lib/bh/classes/nav.rb
@@ -5,17 +5,19 @@ module Bh
     class Nav < Base
       # @return [#to_s] the style-related class to assign to the nav.
       def style_class
-        styles[@options[:as]]
+        Nav.styles[@options[:as]]
       end
 
       # @return [#to_s] the layout-related class to assign to the nav.
       def layout_class
-        layouts[@options[:layout]]
+        Nav.layouts[@options[:layout]]
       end
+
+    private
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to navs for each possible style.
-      def styles
+      def self.styles
         HashWithIndifferentAccess.new(:'nav-tabs').tap do |klass|
           klass[:pills] = :'nav-pills'
         end
@@ -23,7 +25,7 @@ module Bh
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to buttons for each possible layout.
-      def layouts
+      def self.layouts
         HashWithIndifferentAccess.new.tap do |klass|
           klass[:justified] = :'nav-justified'
           klass[:stacked]   = :'nav-stacked'

--- a/lib/bh/classes/navbar.rb
+++ b/lib/bh/classes/navbar.rb
@@ -5,17 +5,17 @@ module Bh
     class Navbar < Base
       # @return [#to_s] the style-related class to assign to the navbar.
       def style_class
-        styles[@options[:inverted]]
+        Navbar.styles[@options[:inverted]]
       end
 
       # @return [#to_s] the position-related class to assign to the navbar.
       def position_class
-        positions[@options[:position]]
+        Navbar.positions[@options[:position]]
       end
 
       # @return [#to_s] the layout-related class to assign to the navbar.
       def layout_class
-        layouts[@options[:fluid]]
+        Navbar.layouts[@options[:fluid]]
       end
 
       def id
@@ -34,9 +34,11 @@ module Bh
         end
       end
 
+    private
+
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to navbars to specify a color combination.
-      def styles
+      def self.styles
         HashWithIndifferentAccess.new(:'navbar-default').tap do |klass|
           klass[true] = :'navbar-inverse'
         end
@@ -44,7 +46,7 @@ module Bh
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to navbars to set a specific DOM position.
-      def positions
+      def self.positions
         HashWithIndifferentAccess.new.tap do |klass|
           klass[:static]        = :'navbar-static-top'
           klass[:static_top]    = :'navbar-static-top'
@@ -57,13 +59,11 @@ module Bh
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to the navbar container for each possible layout.
-      def layouts
+      def self.layouts
         HashWithIndifferentAccess.new(:'container').tap do |klass|
           klass[true] = :'container-fluid'
         end
       end
-
-    private
 
       def body_padding_amount
         @options.fetch :padding, 70

--- a/lib/bh/classes/panel.rb
+++ b/lib/bh/classes/panel.rb
@@ -16,7 +16,7 @@ module Bh
 
       # @return [#to_s] the content-related class to assign to the panel.
       def context_class
-        contexts[@options[:context]]
+        Panel.contexts[@options[:context]]
       end
 
       # @return [#to_s] the HTML tag to wrap the panel in.
@@ -32,18 +32,6 @@ module Bh
 
       def merge_html!(html)
         @content ||= html
-      end
-
-      # @return [Hash<Symbol, String>] the class that Bootstrap requires to
-      #   append to an panel box based on its context.
-      def contexts
-        HashWithIndifferentAccess.new(:'panel-default').tap do |klass|
-          klass[:primary]   = :'panel-primary'
-          klass[:success] = :'panel-success'
-          klass[:info]    = :'panel-info'
-          klass[:warning] = :'panel-warning'
-          klass[:danger]  = :'panel-danger'
-        end
       end
 
       def body
@@ -65,6 +53,18 @@ module Bh
       def title
         if @options[:title]
           @app.content_tag :h3, @options[:title], class: 'panel-title'
+        end
+      end
+
+      # @return [Hash<Symbol, String>] the class that Bootstrap requires to
+      #   append to an panel box based on its context.
+      def self.contexts
+        HashWithIndifferentAccess.new(:'panel-default').tap do |klass|
+          klass[:primary]   = :'panel-primary'
+          klass[:success] = :'panel-success'
+          klass[:info]    = :'panel-info'
+          klass[:warning] = :'panel-warning'
+          klass[:danger]  = :'panel-danger'
         end
       end
     end

--- a/lib/bh/classes/progress_bar.rb
+++ b/lib/bh/classes/progress_bar.rb
@@ -5,17 +5,17 @@ module Bh
     class ProgressBar < Base
       # @return [#to_s] the context-related class to assign to the progress bar.
       def context_class
-        contexts[@options[:context]]
+        ProgressBar.contexts[@options[:context]]
       end
 
       # @return [#to_s] the class to assign to make the progress bar striped.
       def striped_class
-        stripes[@options[:striped]]
+        ProgressBar.stripes[@options[:striped]]
       end
 
       # @return [#to_s] the class to assign to make the progress bar aniamted.
       def animated_class
-        animations[@options[:animated]]
+        ProgressBar.animations[@options[:animated]]
       end
 
       # @return [#to_s] the text to display as the label of the progress bar.
@@ -38,9 +38,11 @@ module Bh
         end
       end
 
+    private
+
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to the progress bar for each possible context.
-      def contexts
+      def self.contexts
         HashWithIndifferentAccess.new.tap do |klass|
           klass[:danger]  = :'progress-bar-danger'
           klass[:info]    = :'progress-bar-info'
@@ -51,7 +53,7 @@ module Bh
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to the progress bar to make it look striped.
-      def stripes
+      def self.stripes
         HashWithIndifferentAccess.new.tap do |klass|
           klass[true]  = :'progress-bar-striped'
         end
@@ -59,7 +61,7 @@ module Bh
 
       # @return [Hash<Symbol, String>] the classes that Bootstrap requires to
       #   append to the progress bar to make it look animated.
-      def animations
+      def self.animations
         HashWithIndifferentAccess.new.tap do |klass|
           klass[true]  = :'progress-bar-striped active'
         end
@@ -72,8 +74,6 @@ module Bh
           label[false]  = @app.content_tag(:span, text, class: 'sr-only')
         end
       end
-
-    private
 
       def percentage
         @options.fetch :percentage, 0

--- a/spec/rails/button_to_helper_spec.rb
+++ b/spec/rails/button_to_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 require 'bh/core_ext/rails/button_to_helper'
 require 'bh/helpers/navbar_helper'

--- a/spec/rails/form/check_box_helper_spec.rb
+++ b/spec/rails/form/check_box_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/field_helper_spec.rb
+++ b/spec/rails/form/field_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/fields_for_helper_spec.rb
+++ b/spec/rails/form/fields_for_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/fieldset_helper_spec.rb
+++ b/spec/rails/form/fieldset_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/file_field_helper_spec.rb
+++ b/spec/rails/form/file_field_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/legend_helper_spec.rb
+++ b/spec/rails/form/legend_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/radio_button_helper_spec.rb
+++ b/spec/rails/form/radio_button_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/select_helper_spec.rb
+++ b/spec/rails/form/select_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/static_control_helper_spec.rb
+++ b/spec/rails/form/static_control_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form/submit_helper_spec.rb
+++ b/spec/rails/form/submit_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails/form_for_helper_spec.rb
+++ b/spec/rails/form_for_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'bh/core_ext/rails/form_for_helper'
 include Bh::Rails::Helpers
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+
+class User
+  require 'active_model'
+
+  include ActiveModel::Validations
+  include ActiveModel::Conversion
+  extend ActiveModel::Naming
+
+  attr_accessor :name
+
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+
+  def persisted?
+    false
+  end
+end
+
+require 'action_view'
+include ActionView::Helpers::FormOptionsHelper
+include defined?(ActionView::VERSION) ? ActionView::RecordIdentifier : ActionController::RecordIdentifier
+I18n.enforce_available_locales = true

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -4,8 +4,6 @@ require 'action_view'
 describe 'When used in Rails' do
   let(:bh) { RailsView.new }
 
-  include ActionView::Context # for capture
-
   all_tests_pass_for 'the alert_box helper'
   all_tests_pass_for 'the bootstrap_css helper'
   all_tests_pass_for 'the bootstrap_js helper'

--- a/spec/shared/alert_box_helper.rb
+++ b/spec/shared/alert_box_helper.rb
@@ -24,7 +24,7 @@ shared_examples_for 'extra alert options' do
 end
 
 shared_examples_for 'the :context alert option' do
-  Bh::AlertBox.new.contexts.each do |context, context_class|
+  Bh::AlertBox.contexts.each do |context, context_class|
     specify %Q{set to :#{context}, adds the class "#{context_class}"} do
       html = %Q{<div class="alert #{context_class}" role="alert">content</div>}
       expect(alert_box: {context: context.to_s}).to generate html

--- a/spec/shared/button_helper.rb
+++ b/spec/shared/button_helper.rb
@@ -25,7 +25,7 @@ shared_examples_for 'extra button options' do
 end
 
 shared_examples_for 'the :context button option' do
-  Bh::Button.new.contexts.each do |context, context_class|
+  Bh::Button.contexts.each do |context, context_class|
     specify %Q{set to :#{context}, adds the class "#{context_class}"} do
       html = %Q{<button class="btn #{context_class}">content</button>}
       expect(button: {context: context}).to generate html
@@ -34,7 +34,7 @@ shared_examples_for 'the :context button option' do
 end
 
 shared_examples_for 'the :size button option' do
-  Bh::Button.new.sizes.each do |size, size_class|
+  Bh::Button.sizes.each do |size, size_class|
     specify %Q{set to :#{size}, adds the class "#{size_class}"} do
       html = %Q{<button class="btn btn-default #{size_class}">content</button>}
       expect(button: {size: size}).to generate html
@@ -43,7 +43,7 @@ shared_examples_for 'the :size button option' do
 end
 
 shared_examples_for 'the :layout button option' do
-  Bh::Button.new.layouts.each do |layout, layout_class|
+  Bh::Button.layouts.each do |layout, layout_class|
     specify %Q{set to :#{layout}, adds the class "#{layout_class}"} do
       html = %Q{<button class="btn btn-default #{layout_class}">content</button>}
       expect(button: {layout: layout}).to generate html

--- a/spec/shared/dropdown_helper.rb
+++ b/spec/shared/dropdown_helper.rb
@@ -29,7 +29,7 @@ shared_examples_for 'no dropdown options' do
 end
 
 shared_examples_for 'the :context dropdown option' do
-  Bh::Button.new.contexts.each do |context, context_class|
+  Bh::Button.contexts.each do |context, context_class|
     specify %Q{set to :#{context}, adds the class "#{context_class}"} do
       html = %r{<button class="dropdown-toggle btn #{context_class}"}
       expect(dropdown: {context: context}).to generate html
@@ -38,7 +38,7 @@ shared_examples_for 'the :context dropdown option' do
 end
 
 shared_examples_for 'the :size dropdown option' do
-  Bh::Button.new.sizes.each do |size, size_class|
+  Bh::Button.sizes.each do |size, size_class|
     specify %Q{set to :#{size}, adds the class "#{size_class}"} do
       html = %r{<button class="dropdown-toggle btn btn-default #{size_class}"}
       expect(dropdown: {size: size}).to generate html
@@ -47,7 +47,7 @@ shared_examples_for 'the :size dropdown option' do
 end
 
 shared_examples_for 'the :layout dropdown option' do
-  Bh::Button.new.layouts.each do |layout, layout_class|
+  Bh::Button.layouts.each do |layout, layout_class|
     specify %Q{set to :#{layout}, adds the class "#{layout_class}"} do
       html = %r{<button class="dropdown-toggle btn btn-default #{layout_class}"}
       expect(dropdown: {layout: layout}).to generate html
@@ -56,7 +56,7 @@ shared_examples_for 'the :layout dropdown option' do
 end
 
 shared_examples_for 'the :groupable dropdown option' do
-  Bh::Dropdown.new.groupables.each do |groupable, groupable_class|
+  Bh::Dropdown.groupables.each do |groupable, groupable_class|
     specify %Q{set to :#{groupable}, adds the class "#{groupable_class}"} do
       html = %r{^<div class="#{groupable_class}">}
       expect(dropdown: {groupable: groupable}).to generate html
@@ -65,7 +65,7 @@ shared_examples_for 'the :groupable dropdown option' do
 end
 
 shared_examples_for 'the :direction dropdown option' do
-  Bh::Dropdown.new.directions.each do |direction, direction_class|
+  Bh::Dropdown.directions.each do |direction, direction_class|
     specify %Q{set to :#{direction}, adds the class "#{direction_class}"} do
       html = %r{^<div class="btn-group #{direction_class}">}
       expect(dropdown: {direction: direction}).to generate html
@@ -74,7 +74,7 @@ shared_examples_for 'the :direction dropdown option' do
 end
 
 shared_examples_for 'the :align dropdown option' do
-  Bh::Dropdown.new.aligns.each do |align, align_class|
+  Bh::Dropdown.aligns.each do |align, align_class|
     specify %Q{set to :#{align}, adds the class "#{align_class}"} do
       html = %r{<ul class="dropdown-menu #{align_class}" role="menu"}
       expect(dropdown: {align: align}).to generate html

--- a/spec/shared/icon_helper.rb
+++ b/spec/shared/icon_helper.rb
@@ -22,7 +22,7 @@ shared_examples_for 'extra icon options' do
 end
 
 shared_examples_for 'the :library icon option' do
-  Bh::Icon.new.libraries.each do |library, library_class|
+  Bh::Icon.libraries.each do |library, library_class|
     specify %Q{set to :#{library}, adds the class "#{library_class}"} do
       html = %Q{<span class="#{library_class} #{library_class}-zoom-in"></span>}
       expect(icon: {library: library}).to generate html

--- a/spec/shared/modal_helper.rb
+++ b/spec/shared/modal_helper.rb
@@ -62,7 +62,7 @@ shared_examples_for 'the :title modal option' do
 end
 
 shared_examples_for 'the :size modal option'do
-  Bh::Modal.new.dialog_sizes.each do |size, size_class|
+  Bh::Modal.dialog_sizes.each do |size, size_class|
     specify %Q{set to :#{size}, adds the class "#{size_class}"}  do
       html = %r{<div class="modal-dialog #{size_class}">}
       expect(modal: {size: size}).to generate html
@@ -78,7 +78,7 @@ shared_examples_for 'the button: :caption modal option' do
 end
 
 shared_examples_for 'the button: :context modal option' do
-  Bh::Button.new.contexts.each do |context, context_class|
+  Bh::Button.contexts.each do |context, context_class|
     specify %Q{set to :#{context}, adds the class "#{context_class}"} do
       html = %r{<button class="btn #{context_class}"}
       expect(modal: {button: {context: context}}).to generate html
@@ -87,7 +87,7 @@ shared_examples_for 'the button: :context modal option' do
 end
 
 shared_examples_for 'the button: :size modal option' do
-  Bh::Button.new.sizes.each do |size, size_class|
+  Bh::Button.sizes.each do |size, size_class|
     specify %Q{set to :#{size}, adds the class "#{size_class}"} do
       html = %r{<button class="btn btn-default #{size_class}"}
       expect(modal: {button: {size: size}}).to generate html

--- a/spec/shared/nav_helper.rb
+++ b/spec/shared/nav_helper.rb
@@ -24,7 +24,7 @@ shared_examples_for 'extra nav options' do
 end
 
 shared_examples_for 'the :as nav option' do
-  Bh::Nav.new.styles.each do |style, style_class|
+  Bh::Nav.styles.each do |style, style_class|
     specify %Q{set to :#{context}, sets the class "#{style_class}"} do
       html = %r{<ul class="nav #{style_class}"}
       expect(nav: {as: style}).to generate html
@@ -33,7 +33,7 @@ shared_examples_for 'the :as nav option' do
 end
 
 shared_examples_for 'the :layout nav option' do
-  Bh::Nav.new.layouts.each do |layout, layout_class|
+  Bh::Nav.layouts.each do |layout, layout_class|
     specify %Q{set to :#{layout}, adds the class "#{layout_class}"} do
       html = %r{<ul class="nav nav-tabs #{layout_class}"}
       expect(nav: {layout: layout}).to generate html

--- a/spec/shared/navbar_helper.rb
+++ b/spec/shared/navbar_helper.rb
@@ -22,7 +22,7 @@ shared_examples_for 'no navbar options' do
 end
 
 shared_examples_for 'the :fluid navbar option' do
-  Bh::Navbar.new.layouts.each do |value, fluid_class|
+  Bh::Navbar.layouts.each do |value, fluid_class|
     specify %Q{set to #{value}, sets the class "#{fluid_class}"} do
       html = %r{<div class="#{fluid_class}">}
       expect(navbar: {fluid: value}).to generate html
@@ -31,7 +31,7 @@ shared_examples_for 'the :fluid navbar option' do
 end
 
 shared_examples_for 'the :inverted navbar option' do
-  Bh::Navbar.new.styles.each do |value, inverted_class|
+  Bh::Navbar.styles.each do |value, inverted_class|
     specify %Q{set to #{value}, sets the class "#{inverted_class}"} do
       html = %r{<nav class="navbar #{inverted_class}"}
       expect(navbar: {inverted: value}).to generate html
@@ -40,7 +40,7 @@ shared_examples_for 'the :inverted navbar option' do
 end
 
 shared_examples_for 'the :position navbar option' do
-  Bh::Navbar.new.positions.each do |position, position_class|
+  Bh::Navbar.positions.each do |position, position_class|
     specify %Q{set to #{position}, sets the class "#{position_class}"} do
       html = %r{<nav class="navbar navbar-default #{position_class}"}
       expect(navbar: {position: position}).to generate html

--- a/spec/shared/panel_helper.rb
+++ b/spec/shared/panel_helper.rb
@@ -60,7 +60,7 @@ shared_examples_for 'the :tag panel option' do
 end
 
 shared_examples_for 'the :context panel option' do
-  Bh::Panel.new.contexts.each do |context, context_class|
+  Bh::Panel.contexts.each do |context, context_class|
     specify %Q{set to :#{context}, adds the class "#{context_class}"} do
       html = %r{^<div class="panel #{context_class}">.*</div>$}m
       expect(panel: {context: context}).to generate html

--- a/spec/shared/progress_bar_helper.rb
+++ b/spec/shared/progress_bar_helper.rb
@@ -60,7 +60,7 @@ shared_examples_for 'the :label progress_bar option' do
 end
 
 shared_examples_for 'the :context progress_bar option' do
-  Bh::ProgressBar.new.contexts.each do |context, context_class|
+  Bh::ProgressBar.contexts.each do |context, context_class|
     specify %Q{set to :#{context}, adds the class "#{context_class}"} do
       html = %r{<div.+class="progress-bar #{context_class}"}
       expect(progress_bar: {percentage: 30, context: context}).to generate html

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,32 +16,3 @@ RSpec.configure do |config|
   config.alias_it_should_behave_like_to :all_tests_pass_for, ''
   config.alias_it_should_behave_like_to :all_tests_pass_with, 'with'
 end
-
-
-
-class User
-  require 'active_model'
-
-  include ActiveModel::Validations
-  include ActiveModel::Conversion
-  extend ActiveModel::Naming
-
-  attr_accessor :name
-
-  def initialize(attributes = {})
-    @name = attributes[:name]
-  end
-
-  def persisted?
-    false
-  end
-end
-
-require 'action_view'
-include ActionView::Helpers::FormOptionsHelper
-if defined?(ActionView::VERSION) # only defined in ActionView >=4
-  include ActionView::RecordIdentifier
-else
-  include ActionController::RecordIdentifier
-end
-I18n.enforce_available_locales = true


### PR DESCRIPTION
Only require in Rails-specific tests.
