### PR TITLE
Allow `button_to` to accept button + extra options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-## 1.1.2 - unreleased
+## 1.2.0 - unreleased
 
+* [FEATURE] Extend `button_to` to accept the same :content, :size and :layout options as `button`
+* [ENHANCEMENT] Allow `button_to` to pass extra parameters to the button element
 * [ENHANCEMENT] Don’t render anything when `vertical` and `horizontal` are not wrapped in a `navbar`
 * [ENHANCEMENT] Allow `progress_bar` to pass extra parameters to the wrapping container
 * [ENHANCEMENT] Allow `progress_bar` to pass extra parameters to each bar

--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -140,7 +140,7 @@
 
     <h1>Button to</h1>
 
-      <%= button_to "New", '/#new', method: :get, class: 'btn btn-info' %>
+      <%= button_to "New", '/#new', method: :get, context: :link %>
       <br />
       <%= button_to '#edit', method: :get, class: 'btn btn-default btn-sm' do %>
         Edit <strong>user</strong>

--- a/lib/bh/classes/base.rb
+++ b/lib/bh/classes/base.rb
@@ -68,6 +68,11 @@ module Bh
         @app.content_tag tag, content, attributes
       end
 
+      def url
+        @url
+      end
+
+
     private
 
       def safe_join(array = [])
@@ -98,6 +103,10 @@ module Bh
         else
           args.shift
         end
+      end
+
+      def extract_url_from(*args)
+        args.delete_at(block_given? ? 0 : 1)
       end
 
       def capture_content(&block)

--- a/lib/bh/classes/button_to.rb
+++ b/lib/bh/classes/button_to.rb
@@ -2,7 +2,11 @@ require 'bh/classes/link_to'
 
 module Bh
   module Classes
-    class ButtonTo < LinkTo
+    class ButtonTo < Button
+      def initialize(app = nil, *args, &block)
+        @url = extract_url_from(*args, &block)
+        super
+      end
     end
   end
 end

--- a/lib/bh/classes/link_to.rb
+++ b/lib/bh/classes/link_to.rb
@@ -7,16 +7,6 @@ module Bh
         @url = extract_url_from(*args, &block)
         super
       end
-
-      def url
-        @url
-      end
-
-    private
-
-      def extract_url_from(*args)
-        args.delete_at(block_given? ? 0 : 1)
-      end
     end
   end
 end

--- a/lib/bh/core_ext/rails/button_to_helper.rb
+++ b/lib/bh/core_ext/rails/button_to_helper.rb
@@ -11,7 +11,12 @@ module Bh
       # @see http://getbootstrap.com/components/#navbar-buttons
       def button_to(*args, &block)
         button_to = Bh::ButtonTo.new self, *args, &block
+        button_to.extract! :context, :size, :layout
         button_to.append_class! :btn
+        button_to.append_class! button_to.context_class
+        button_to.append_class! button_to.size_class
+        button_to.append_class! button_to.layout_class
+
         if Bh::Stack.find(Bh::Navbar)
           button_to.append_class_as! :form_class, :'navbar-form'
         end

--- a/spec/shared/button_to_helper.rb
+++ b/spec/shared/button_to_helper.rb
@@ -1,20 +1,59 @@
 shared_examples_for 'the button_to helper' do
   all_tests_pass_with 'no button_to options'
+  all_tests_pass_with 'extra button_to options'
+  all_tests_pass_with 'the :context button_to option'
+  all_tests_pass_with 'the :size button_to option'
+  all_tests_pass_with 'the :layout button_to option'
   all_tests_pass_with 'the button wrapped in navbar'
 end
 
 #--
 
 shared_examples_for 'no button_to options' do
-  specify 'adds the "btn" class to the button' do
-    html = %r{^<form action="/" class="button_to" method="post"><div><(input|button) class="btn" type="submit"(>| value=")content(" />|</button>)</div></form>$}
+  specify 'adds the "btn btn-default" class to the button' do
+    html = %r{^<form action="/" class="button_to" method="post"><div><(input|button) class="btn btn-default" type="submit"(>| value=")content(" />|</button>)</div></form>$}
     expect(:button_to).to generate html
   end
 end
 
+
+shared_examples_for 'extra button_to options' do
+  specify 'passes the options to the button' do
+    options = {class: 'important', data: {value: 1}, id: 'my-button_to'}
+    html = %r{<(input|button) class="important btn btn-default" data-value="1" id="my-button_to" type="submit"}
+    expect(button_to: options).to generate html
+  end
+end
+
+shared_examples_for 'the :context button_to option' do
+  Bh::Button.contexts.each do |context, context_class|
+    specify %Q{set to :#{context}, adds the class "#{context_class}"} do
+      html = %r{<(input|button) class="btn #{context_class}" type="submit"}
+      expect(button_to: {context: context}).to generate html
+    end
+  end
+end
+
+shared_examples_for 'the :size button_to option' do
+  Bh::Button.sizes.each do |size, size_class|
+    specify %Q{set to :#{size}, adds the class "#{size_class}"} do
+      html = %r{<(input|button) class="btn btn-default #{size_class}" type="submit"}
+      expect(button_to: {size: size}).to generate html
+    end
+  end
+end
+
+shared_examples_for 'the :layout button_to option' do
+  Bh::Button.layouts.each do |layout, layout_class|
+    specify %Q{set to :#{layout}, adds the class "#{layout_class}"} do
+      html = %r{<(input|button) class="btn btn-default #{layout_class}" type="submit"}
+      expect(button_to: {layout: layout}).to generate html
+    end
+  end
+end
 shared_examples_for 'the button wrapped in navbar' do
   specify 'adds the "navbar-form" class to the form' do
-    html = %r{^<form action="/" class="navbar-form" method="post"><div><(input|button) class="btn" type="submit"(>| value=")content(" />|</button>)</div></form>$}
+    html = %r{^<form action="/" class="navbar-form" method="post"><div><(input|button) class="btn btn-default" type="submit"(>| value=")content(" />|</button>)</div></form>$}
     bh.navbar { expect(:button_to).to generate html }
   end
 end


### PR DESCRIPTION
After this commit, `button_to` behaves more coherently with `button`
in that `:context`, `:size` and `:layout` options can be used to
modify the appearance of the button, while other options are passed
directly to the button element.
