### PR TITLE
Add Active Option for `link_to` In Navs

### DIFF
--- a/lib/bh/helpers/link_to_helper.rb
+++ b/lib/bh/helpers/link_to_helper.rb
@@ -35,6 +35,11 @@ module Bh
     #         end
     #       end
     def link_to(*args, &block)
+      active = args.extract_options![:active]
+
+      # remove the unwanted active option
+      args.extract_options!.except![:active]
+
       link_to = Bh::LinkTo.new self, *args, &block
 
       link_to.append_class! :'alert-link' if Bh::Stack.find(Bh::AlertBox)
@@ -42,8 +47,6 @@ module Bh
       link_to.merge! role: :menuitem if Bh::Stack.find(Bh::Dropdown)
       link_to.merge! tabindex: -1 if Bh::Stack.find(Bh::Dropdown)
       html = super link_to.content, link_to.url, link_to.attributes, &nil
-
-      active = args.extract_options![:active]
 
       if Bh::Stack.find(Bh::Dropdown)
         container = Bh::Base.new(self) { html }

--- a/lib/bh/helpers/link_to_helper.rb
+++ b/lib/bh/helpers/link_to_helper.rb
@@ -43,13 +43,15 @@ module Bh
       link_to.merge! tabindex: -1 if Bh::Stack.find(Bh::Dropdown)
       html = super link_to.content, link_to.url, link_to.attributes, &nil
 
+      active = args.extract_options![:active]
+
       if Bh::Stack.find(Bh::Dropdown)
         container = Bh::Base.new(self) { html }
         container.merge! role: :presentation
         container.render_tag :li
       elsif Bh::Stack.find(Bh::Nav)
         container = Bh::Base.new(self) { html }
-        container.append_class! :active if link_to.current_page?
+        container.append_class! :active if link_to.current_page? || active
         container.render_tag :li
       else
         html

--- a/spec/shared/link_to_helper.rb
+++ b/spec/shared/link_to_helper.rb
@@ -52,6 +52,14 @@ shared_examples_for 'the link wrapped in nav' do
       bh.nav { expect(:link_to).to generate html }
     end
   end
+
+  describe 'if the link is given the active option' do
+    specify 'surrounds the link in a <li class="active"> item' do
+      options = { active: true }
+      html = '<li class="active"><a href="/">content</a></li>'
+      bh.nav { expect(link_to: options).to generate html }
+    end
+  end
 end
 
 shared_examples_for 'the link wrapped in vertical' do


### PR DESCRIPTION
Super simple, just add in an active option for `link_to` when inside a `nav`

Use Case:
```rhtml
<%= nav as: :pills, layout: :stacked, class: 'foo-sidebar' do %>
  <%= link_to 'X', '#x' %>
  <%= link_to 'Y', '#y' %>
  <%= link_to 'Z', '#z' %>
<% end %>
```

Currently, because of the way that `current_page?` works, even if the user is on the page "/#y" the nav item will not get highlighted as active. This is because hash attributes are not sent down to the server. 

Generally the accepted workaround is to manually control the class on each `<li>` through javascript. This PR does not solve this issue without the use of javascript, but it does let the implementer define which member of the `nav` should be highlighted as active first.

Here is what the proposed option would look like in the above example:

```rhtml
<%= nav as: :pills, layout: :stacked, class: 'foo-sidebar' do %>
  <%= link_to 'X', '#x', active: true %>
  <%= link_to 'Y', '#y' %>
  <%= link_to 'Z', '#z' %>
<% end %>
```
If there are any style / code / whatever pieces of feedback or any questions please let me know!

Happy to finally have some time to work on BH!

<3 Kyle