### PR TITLE
Don’t assume that the content of `link_to` is safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.3.4 - 2014-06-23
+
+* [BUGFIX] Security: don’t always assume that the content of `link_to` is safe
+
+Note that this might break your code if it relied on the wrong behavior of
+Bh, assuming that the content of `link_to` was always HTML safe.
+
+For instance, if your app has the following code to display an image with a
+link `link_to '<img src="logo.png">', '/'`, then the image will not display
+anymore, since Bh now correctly escapes the HTML content (as Rails and Padrino
+do). In this case, you should use `link_to image_tag('logo.png'), '/'` instead.
+
 ## 1.3.3 - 2014-03-11
 
 * [BUGFIX] Correctly align the "X" icon at the right of the field in basic forms

--- a/lib/bh/classes/base.rb
+++ b/lib/bh/classes/base.rb
@@ -59,7 +59,7 @@ module Bh
         items = Array.wrap(@content).map do |item|
           item.is_a?(Base) ? item.content_tag(item.tag) : item
         end
-        safe_join items
+        items.all?(&:html_safe?) ? safe_join(items) : items.join
       end
 
       def content_tag(tag)

--- a/lib/bh/version.rb
+++ b/lib/bh/version.rb
@@ -1,3 +1,3 @@
 module Bh
-  VERSION = '1.3.3'
+  VERSION = '1.3.4'
 end

--- a/spec/shared/link_to_helper.rb
+++ b/spec/shared/link_to_helper.rb
@@ -5,6 +5,8 @@ shared_examples_for 'the link_to helper' do
   all_tests_pass_with 'the link wrapped in dropdown'
   all_tests_pass_with 'the link wrapped in nav'
   all_tests_pass_with 'the link wrapped in vertical'
+  all_tests_pass_with 'the link including unsafe Javascript'
+  all_tests_pass_with 'the link including safe HTML content'
 end
 
 #--
@@ -60,5 +62,23 @@ shared_examples_for 'the link wrapped in vertical' do
     bh.navbar(id: 'id') do
       bh.vertical { expect(:link_to).to generate html }
     end
+  end
+end
+
+shared_examples_for 'the link including unsafe Javascript' do
+  specify 'uses the original link_to helper which escapes the link' do
+    expect(link_to: :xss_script).not_to generate %r{<script>}
+    bh.alert_box { expect(link_to: :xss_script).not_to generate %r{<script>} }
+    bh.dropdown('') { expect(link_to: :xss_script).not_to generate %r{<script>} }
+    bh.nav { expect(link_to: :xss_script).not_to generate %r{<script>} }
+    bh.navbar(id: 'id') do
+      bh.vertical { expect(link_to: :xss_script).not_to generate %r{<script>} }
+    end
+  end
+end
+
+shared_examples_for 'the link including safe HTML content' do
+  specify 'does not escape the HTML content' do
+    expect(link_to: :safe_html).to generate %r{<hr />}
   end
 end

--- a/spec/shared/link_to_helper.rb
+++ b/spec/shared/link_to_helper.rb
@@ -55,8 +55,10 @@ shared_examples_for 'the link wrapped in nav' do
 end
 
 shared_examples_for 'the link wrapped in vertical' do
-  specify 'surrounds the link in a <li> item' do
-    html = '<li><a href="/">content</a></li>'
-    bh.vertical { expect(:link_to).to generate html }
+  specify 'adds the "navbar-brand" class to the link' do
+    html = %r{^<a.+class="navbar-brand".*>content</a>$}
+    bh.navbar(id: 'id') do
+      bh.vertical { expect(:link_to).to generate html }
+    end
   end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -7,6 +7,12 @@ RSpec::Matchers.define :generate do |html|
     if helper == :link_to && options == :nil_name
       @inline = bh.send helper, nil, '/'
       @block = @inline
+    elsif helper == :link_to && options == :xss_script
+      @inline = bh.send helper, '<script>alert("xss")</script>', '/'
+      @block = bh.send(helper, '/') { '<script>alert("xss")</script>' }
+    elsif helper == :link_to && options == :safe_html
+      @inline = bh.send helper, bh.tag(:hr), '/'
+      @block = bh.send(helper, '/') { bh.tag(:hr) }
     elsif helper == :link_to || helper == :button_to
       @inline = bh.send helper, *['content', '/', options].compact
       if bh.test_button_to_with_block


### PR DESCRIPTION
Closes #138 – Security fix

Before this commit, `link_to '<script>alert("xss")</script>', '/'` would actually execute the Javascript in the browser, resulting in a security issue (XSS).

After this commit, Bh does not always assume that the content of `link_to` is HTML-safe, but correctly lets the super method (of Rails of Padrino) deal with this.