### PR TITLE
In a nested form, options[:errors] can be nil

### DIFF
--- a/lib/bh/core_ext/rails/form/base_helper.rb
+++ b/lib/bh/core_ext/rails/form/base_helper.rb
@@ -75,7 +75,7 @@ module Bh
       def show_error_icon?(field_type, errors, suffix = nil)
         no_icon = %w(checkbox number_field radio_button select legend)
         hide = no_icon.include?(field_type.to_s)
-        errors.any? && @options.fetch(:errors, {}).fetch(:icons, true) && !hide && suffix.nil?
+        errors.any? && (@options.fetch(:errors) || {}).fetch(:icons, true) && !hide && suffix.nil?
       end
 
       def error_icon_tag

--- a/lib/bh/core_ext/rails/form/base_helper.rb
+++ b/lib/bh/core_ext/rails/form/base_helper.rb
@@ -131,7 +131,7 @@ module Bh
       end
 
       def show_error_help?
-        @options.fetch(:errors, {}).fetch(:messages, :inline).to_s == 'inline'
+        (@options.fetch(:errors) || {}).fetch(:messages, :inline).to_s == 'inline'
       end
 
       def inline_form?


### PR DESCRIPTION
The problem here is:

    { errors: nil }.fetch(:errors, {}) #==> nil

but the code expects:

    ({ errors: nil }.fetch(:errors) || {}) #==> {}

for the chained ```#fetch``` to work.

These patches fix the two problematic lines, though a more sophisticated patch should fix why in ```fields_for``` can the key exists with a nil value in first place.