### PR TITLE
the modal helper now accepts an animated: option

### DIFF
--- a/examples/middleman/source/index.html.erb
+++ b/examples/middleman/source/index.html.erb
@@ -50,7 +50,7 @@
         <!-- Try setting different :title, :size, :button or :context options -->
         <%= modal 'Do what you want!', button: {size: :small, context: :info} %>
 
-        <% modal size: :large, id: 'modal', button: {class: :en} do %>
+        <% modal size: :large, id: 'modal', button: {class: :en}, animated: false do %>
           <div class="modal-body">Please accept the Terms of service.</div>
           <div class="modal-footer"><button type="button" class="btn btn-primary">Accept</button></div>
         <% end %>

--- a/examples/padrino/app/views/index.html.erb
+++ b/examples/padrino/app/views/index.html.erb
@@ -47,7 +47,7 @@
         <!-- Try setting different :title, :size, :button or :context options -->
         <%= modal 'Do what you want!', button: {size: :small, context: :info} %>
 
-        <% modal title: 'Terms of service', size: :large, id: 'modal', button: {class: :en} do %>
+        <% modal title: 'Terms of service', size: :large, id: 'modal', button: {class: :en}, animated: false do %>
           <div class="modal-body">Please accept the Terms of service.</div>
           <div class="modal-footer"><button type="button" class="btn btn-primary">Accept</button></div>
         <% end %>

--- a/examples/rails/app/views/application/index.html.erb
+++ b/examples/rails/app/views/application/index.html.erb
@@ -47,7 +47,7 @@
       <!-- Try setting different :title, :size, :button or :context options -->
       <%= modal 'Do what you want!', button: {size: :small, context: :info} %>
 
-      <%= modal title: 'Terms of service', size: :large, id: 'modal', button: {class: :en} do %>
+      <%= modal title: 'Terms of service', size: :large, id: 'modal', button: {class: :en}, animated: false do %>
         <div class="modal-body">Please accept the Terms of service.</div>
         <div class="modal-footer"><button type="button" class="btn btn-primary">Accept</button></div>
       <% end %>

--- a/lib/bh/classes/modal.rb
+++ b/lib/bh/classes/modal.rb
@@ -29,6 +29,11 @@ module Bh
         Modal.dialog_sizes[@options[:size]]
       end
 
+      # @return [#to_s] the animation-related class to assign to the modal.
+      def animation_class
+        Modal.animation_class if @options.fetch :animated, true
+      end
+
       # @return [#to_s] the caption for the modal button.
       def caption
         @options.fetch(:button, {}).fetch :caption, title
@@ -54,6 +59,11 @@ module Bh
           klass[:sm]          = :'modal-sm'
           klass[:small]       = :'modal-sm'
         end
+      end
+
+      # @return [#to_s] the class that defines the modal's animation.
+      def self.animation_class
+        'fade'
       end
 
       def extract_content_from(*args, &block)

--- a/lib/bh/helpers/modal_helper.rb
+++ b/lib/bh/helpers/modal_helper.rb
@@ -24,6 +24,8 @@ module Bh
     #       (alias `:xs`), `:large` (alias `:lg`) or `:small` (alias `:sm`).
     #     * :layout (#to_s) if set to `:block`, span the button for the full
     #       width of the parent.
+    #   @option options [Boolean] :animated (true) option for disabling the
+    #   default modal animation.
     #   @example Display a simple modal toggled by a blue button.
     #       modal 'You clicked me!', title: 'Click me', button: {context: :info}
     # @overload modal(options = {}, &block)
@@ -37,7 +39,9 @@ module Bh
     #       end
     def modal(*args, &block)
       modal = Bh::Modal.new self, *args, &block
-      modal.extract! :button, :size, :body, :title, :id
+      modal.extract! :animated, :button, :size, :body, :title, :id
+
+      modal.append_class_to! :animation, modal.animation_class
 
       modal.extract_from :button, [:context, :size, :layout, :caption]
       modal.append_class_to! :button, :btn

--- a/lib/bh/views/bh/_modal.html.erb
+++ b/lib/bh/views/bh/_modal.html.erb
@@ -1,5 +1,5 @@
 <button class="<%= button[:class] %>" data-toggle="modal" data-target="#<%= div[:id] %>"><%= button[:caption] %></button>
-<div class="modal fade" id="<%= div[:id] %>" tabindex="-1" role="dialog" aria-labelledby="label-<%= div[:id] %>" aria-hidden="true">
+<div class="modal <%= animation[:class] %>" id="<%= div[:id] %>" tabindex="-1" role="dialog" aria-labelledby="label-<%= div[:id] %>" aria-hidden="true">
   <div class="<%= div[:class] %>">
     <div class="modal-content">
       <div class="modal-header">

--- a/spec/shared/modal_helper.rb
+++ b/spec/shared/modal_helper.rb
@@ -8,6 +8,7 @@ shared_examples_for 'the modal helper' do
   all_tests_pass_with 'the button: :context modal option'
   all_tests_pass_with 'the button: :size modal option'
   all_tests_pass_with 'the button: :class modal option'
+  all_tests_pass_with 'the animated: modal option'
 end
 
 #--
@@ -100,5 +101,17 @@ shared_examples_for 'the button: :class modal option' do
   specify 'appends the class to the modal button' do
     html = %r{<button class="important btn btn-default"}
     expect(modal: {button: {class: 'important'}}).to generate html
+  end
+end
+
+shared_examples_for 'the animated: modal option' do
+  specify 'set to true, keeps the class "fade"' do
+    html = %r{<div class="modal fade" id=}
+    expect(modal: {animated: true}).to generate html
+  end
+
+  specify 'set to false, removes the class "fade"' do
+    html = %r{<div class="modal.*" id=}
+    expect(modal: {animated: false}).to generate html
   end
 end


### PR DESCRIPTION
At the moment, the modal template adds the `fade` class to every modal, which is responsible for animating the opening/closing of a modal. If you want this animation gone, you currently have to override the `fade` class, or use some other workaround.
To fix that, this PR adds an `animated:` modal option. If `animated: false` is passed, the `fade` class will not be added, [which is what bootstrap suggests to remove the animation](http://stackoverflow.com/questions/10143444/twitter-bootstrap-modal-how-to-remove-slide-down-effect).

Please let me know what you think.