### PR TITLE
Support Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ matrix:
       - gem update --system 2.4.8
   - rvm: 2.0.0
     gemfile: gemfiles/Gemfile.rails-4.x
+  - rvm: 2.2.4
+    gemfile: gemfiles/Gemfile.rails-5.x
+    env: ONLY_RAILS=true

--- a/bh.gemspec
+++ b/bh.gemspec
@@ -33,10 +33,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'tins',            '~> 1.5.4'
   spec.add_development_dependency 'activemodel'      # versioned in gemfiles/
 
-  # For spec/dummy
-  spec.add_development_dependency 'middleman-core'   # versioned in gemfiles/
+  unless ENV['ONLY_RAILS']
+    # For spec/dummy
+    spec.add_development_dependency 'middleman-core'   # versioned in gemfiles/
 
-  # For Middleman/Padrino tests
-  spec.add_development_dependency 'padrino-helpers', '~> 0.12.4'
-  spec.add_development_dependency 'padrino-routing', '~> 0.5.0'
+    # For Middleman/Padrino tests
+    spec.add_development_dependency 'padrino-helpers', '~> 0.12.4'
+    spec.add_development_dependency 'padrino-routing', '~> 0.5.0'
+  end
 end

--- a/gemfiles/Gemfile.rails-5.x
+++ b/gemfiles/Gemfile.rails-5.x
@@ -1,0 +1,7 @@
+source 'http://rubygems.org'
+
+gem 'activesupport', '>= 5.0.0.beta1'
+gem 'actionpack', '>= 5.0.0.beta1'
+gem 'activemodel', '>= 5.0.0.beta1'
+
+gemspec path: '../'

--- a/spec/padrino_spec.rb
+++ b/spec/padrino_spec.rb
@@ -26,4 +26,4 @@ describe 'When used in Padrino or Middleman' do
   all_tests_pass_for 'the button_to helper (Padrino)'
   all_tests_pass_for 'the link_to helper (Padrino)'
   all_tests_pass_for 'the link_to helper'
-end
+end unless ENV['ONLY_RAILS']

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-
 class User
   require 'active_model'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,9 @@ SimpleCov.start
 require 'bh'
 
 Dir['./spec/shared/**/*.rb'].each {|f| require f}
-Dir['./spec/support/**/*.rb'].each {|f| require f}
+require './spec/support/matchers.rb'
+require './spec/support/padrino.rb' unless ENV['ONLY_RAILS']
+require './spec/support/rails.rb'
 
 RSpec.configure do |config|
   config.order = 'random'


### PR DESCRIPTION
There is nothing to change in the code, just add Rails 5 beta in
the testing matrix for Travis.

Note that ActiveSupport 5 is currently incompatible with middleman,
so in the case of testing Rails 5, I don't test Middleman/Padrino.