### PR TITLE
Add failing test for fields_for validation

### DIFF
--- a/spec/rails/form/fields_for_helper_spec.rb
+++ b/spec/rails/form/fields_for_helper_spec.rb
@@ -62,4 +62,15 @@ describe 'fields_for' do
       it { expect(form).to include '<div class="panel-heading">Your address</div>' }
     end
   end
+
+  context 'given a record object with validation error' do
+    before { user.errors.add :name, 'is required' }
+
+    let(:block) { Proc.new {|f| f.fields_for :other_user, user, options, &fields_block } }
+    let(:fields_block) { Proc.new {|f| f.text_field :name } }
+
+    specify 'shows error' do
+      expect(form).to include 'has-error'
+    end
+  end
 end


### PR DESCRIPTION
Form builder methods called within
a fields_for block generate NoMethodError
by calling fetch on nil when rendering
validation error messages from the
associated object. This PR includes
a failing test demonstrating the bug, not
the fix itself.

The actual fix was previously submitted by @MichaelSp in PR #146, but since that has been open for a while, I'm hoping contributing a test will help move it along.
