### PR TITLE
alert: add alert-dismissible class

### DIFF
--- a/lib/bh/classes/alert_box.rb
+++ b/lib/bh/classes/alert_box.rb
@@ -7,6 +7,11 @@ module Bh
       def context_class
         AlertBox.contexts[@options.fetch :context, @options[:priority]]
       end
+    
+      # @return [#to_s] the css class which indicates this box is dimissible, to assign to the alert box.
+      def dismissible_class
+        'alert-dismissible' if @options[:dismissible]
+      end
 
       # @return [#to_s] the HTML to show a dismissible button for the alert box.
       def dismissible_button

--- a/lib/bh/helpers/alert_box_helper.rb
+++ b/lib/bh/helpers/alert_box_helper.rb
@@ -32,6 +32,7 @@ module Bh
 
       alert_box.append_class! :alert
       alert_box.append_class! alert_box.context_class
+      alert_box.append_class! alert_box.dismissible_class
       alert_box.merge! role: :alert
       alert_box.prepend_html! alert_box.dismissible_button
       alert_box.render_tag :div

--- a/spec/shared/alert_box_helper.rb
+++ b/spec/shared/alert_box_helper.rb
@@ -1,4 +1,5 @@
 shared_examples_for 'the alert_box helper' do
+  # based on https://getbootstrap.com/components/#alerts
   all_tests_pass_with 'no alert options'
   all_tests_pass_with 'extra alert options'
   all_tests_pass_with 'the :context alert option'
@@ -36,6 +37,11 @@ shared_examples_for 'the :dismissible alert option' do
   specify 'set to false, does not display a button to dismiss the alert' do
     html = '<div class="alert alert-info" role="alert">content</div>'
     expect(alert_box: {dismissible: false}).to generate html
+  end
+  
+  specify 'set to true, adds class alert-dismissible to the alert div' do
+    html = %r{<div class="alert alert-info alert-dismissible"}
+    expect(alert_box: {dismissible: true}).to generate html
   end
 
   specify 'set to true, displays a button to dismiss the alert' do


### PR DESCRIPTION
Per https://getbootstrap.com/components/#alerts-dismissible, alert boxes should have an alert-dismissable class.