### PR TITLE
Add a frozen_string_literal_comment in icon.rb

### DIFF
--- a/lib/bh/classes/icon.rb
+++ b/lib/bh/classes/icon.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bh/classes/base'
 
 module Bh


### PR DESCRIPTION
- Shave a few thousand object allocations off, depending on your app